### PR TITLE
add `langsan` sanitization feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "misanthropic"
-version = "0.3.3"
+version = "0.4.0"
 edition = "2021"
 authors = ["Michael de Gans <michael.john.degans@gmail.com>"]
 description = "An async, ergonomic, client for Anthropic's Messages API"
@@ -37,6 +37,15 @@ thiserror = "1"
 pulldown-cmark = { version = "0.12", optional = true }
 pulldown-cmark-to-cmark = { version = "17", optional = true }
 static_assertions = "1"
+langsan = { version = "0", features = [
+    "english",
+    "french",
+    "german",
+    "italian",
+    "serde",
+    "emoji",
+    "verbose",
+], optional = true }
 
 [dev-dependencies]
 # for all examples
@@ -51,7 +60,7 @@ tempfile = "3.12"
 
 [features]
 # rustls because I am sick of getting Dependabot alerts for OpenSSL.
-default = ["rustls-tls"]
+default = ["rustls-tls", "langsan"]
 # Image crate support. Note that images are supported without this feature but
 # you must handle encoding/decoding yourself. This is mostly for interop with
 # the `image` crate.
@@ -78,6 +87,8 @@ rustls-tls = ["reqwest/rustls-tls"]
 markdown = ["dep:pulldown-cmark", "dep:pulldown-cmark-to-cmark"]
 # Derive PartialEq for all structs and enums.
 partialeq = []
+# Input and output sanitization
+langsan = ["dep:langsan"]
 
 [[example]]
 name = "strawberry"

--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ println!("{}", message);
 - [x] Prompt caching support
 - [x] Custom request and endpoint support
 - [x] Zero-copy where possible
+- [x] [Sanitization](https://crates.io/crates/langsan) of input and output to mitigate [injection attacks](https://arstechnica.com/security/2024/10/ai-chatbots-can-read-and-write-invisible-text-creating-an-ideal-covert-channel/)
 - [ ] Amazon Bedrock support
 - [ ] Vertex AI support
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -536,6 +536,6 @@ mod tests {
             .await
             .unwrap();
 
-        assert!(msg.contains("🙏"));
+        assert_eq!(msg, "🙏");
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,6 +36,11 @@ pub use response::Response;
 /// Markdown utilities for parsing and rendering.
 pub mod markdown;
 
+#[cfg(not(feature = "langsan"))]
+pub(crate) type CowStr<'a> = std::borrow::Cow<'a, str>;
+#[cfg(feature = "langsan")]
+pub(crate) type CowStr<'a> = langsan::CowStr<'a>;
+
 /// Re-exports of commonly used crates to avoid version conflicts and reduce
 /// dependency bloat.
 pub mod exports {
@@ -44,6 +49,8 @@ pub mod exports {
     pub use futures;
     #[cfg(feature = "image")]
     pub use image;
+    #[cfg(feature = "langsan")]
+    pub use langsan;
     #[cfg(feature = "log")]
     pub use log;
     pub use memsecurity;

--- a/src/prompt.rs
+++ b/src/prompt.rs
@@ -577,18 +577,6 @@ mod tests {
 
     use crate::prompt::message::Role;
 
-    const MESSAGE: Message = Message {
-        role: Role::User,
-        content: Content::text("Hello"),
-    };
-
-    const MESSAGE2: Message = Message {
-        role: Role::Assistant,
-        content: Content::text("Hi"),
-    };
-
-    const MESSAGES: [Message; 2] = [MESSAGE, MESSAGE2];
-
     const STOP_SEQUENCES: [&'static str; 2] = ["stop1", "stop2"];
 
     // Credit to GitHub Copilot for the following tests.
@@ -629,26 +617,41 @@ mod tests {
         assert_eq!(request.model, model);
     }
 
+    fn create_test_messages() -> [Message<'static>; 2] {
+        let message = Message {
+            role: Role::User,
+            content: Content::text("Hello"),
+        };
+
+        let message2 = Message {
+            role: Role::Assistant,
+            content: Content::text("Hi"),
+        };
+
+        [message, message2]
+    }
+
     #[test]
     fn test_set_messages() {
-        let request = Prompt::default().messages(MESSAGES);
-        assert_eq!(request.messages, MESSAGES);
+        let request = Prompt::default().messages(create_test_messages());
+        assert_eq!(request.messages, create_test_messages());
     }
 
     #[test]
     fn test_add_message() {
-        let mut request = Prompt::default();
-        request = request.add_message(MESSAGE).add_message(MESSAGE2);
-        assert_eq!(request.messages.len(), 2);
-        assert_eq!(request.messages[0], MESSAGE);
-        assert_eq!(request.messages[1], MESSAGE2);
+        let prompt = Prompt::default()
+            .add_message((Role::User, "Hello"))
+            .add_message((Role::Assistant, "Hi"));
+        assert_eq!(prompt.messages.len(), 2);
+        assert_eq!(prompt.messages[0], (Role::User, "Hello").into());
+        assert_eq!(prompt.messages[1], (Role::Assistant, "Hi").into());
     }
 
     #[test]
     fn test_extend_messages() {
         let mut request = Prompt::default();
-        request = request.extend_messages(MESSAGES);
-        assert_eq!(request.messages, MESSAGES);
+        request = request.extend_messages(create_test_messages());
+        assert_eq!(request.messages, create_test_messages());
     }
 
     #[test]

--- a/src/response.rs
+++ b/src/response.rs
@@ -125,28 +125,30 @@ mod tests {
 
     const CONTENT: &str = "Hello, world!";
 
-    const RESPONSE: Response = Response::Message {
-        message: Message {
-            id: Cow::Borrowed(TEST_ID),
-            message: prompt::Message {
-                role: prompt::message::Role::User,
-                content: prompt::message::Content::SinglePart(Cow::Borrowed(
-                    CONTENT,
-                )),
+    fn create_response() -> Response<'static> {
+        Response::Message {
+            message: Message {
+                id: TEST_ID.into(),
+                message: prompt::Message {
+                    role: prompt::message::Role::User,
+                    content: prompt::message::Content::SinglePart(
+                        CONTENT.into(),
+                    ),
+                },
+                model: crate::Model::Sonnet35,
+                stop_reason: None,
+                stop_sequence: None,
+                usage: Usage {
+                    input_tokens: 1,
+                    #[cfg(feature = "prompt-caching")]
+                    cache_creation_input_tokens: Some(2),
+                    #[cfg(feature = "prompt-caching")]
+                    cache_read_input_tokens: Some(3),
+                    output_tokens: 4,
+                },
             },
-            model: crate::Model::Sonnet35,
-            stop_reason: None,
-            stop_sequence: None,
-            usage: Usage {
-                input_tokens: 1,
-                #[cfg(feature = "prompt-caching")]
-                cache_creation_input_tokens: Some(2),
-                #[cfg(feature = "prompt-caching")]
-                cache_read_input_tokens: Some(3),
-                output_tokens: 4,
-            },
-        },
-    };
+        }
+    }
 
     #[test]
     fn test_into_stream() {
@@ -159,7 +161,7 @@ mod tests {
         };
 
         assert!(response.into_stream().is_some());
-        assert!(RESPONSE.into_stream().is_none());
+        assert!(create_response().into_stream().is_none());
     }
 
     #[test]
@@ -178,13 +180,13 @@ mod tests {
     #[test]
     #[should_panic]
     fn test_unwrap_stream_panics() {
-        let _panic = RESPONSE.unwrap_stream();
+        let _panic = create_response().unwrap_stream();
     }
 
     #[test]
     fn test_unwrap_message() {
         assert_eq!(
-            RESPONSE.unwrap_message().content.to_string(),
+            create_response().unwrap_message().content.to_string(),
             "Hello, world!"
         );
     }
@@ -206,7 +208,7 @@ mod tests {
     #[test]
     fn test_message() {
         assert_eq!(
-            RESPONSE.message().unwrap().content.to_string(),
+            create_response().message().unwrap().content.to_string(),
             "Hello, world!"
         );
 
@@ -224,7 +226,11 @@ mod tests {
     #[test]
     fn test_into_message() {
         assert_eq!(
-            RESPONSE.into_message().unwrap().content.to_string(),
+            create_response()
+                .into_message()
+                .unwrap()
+                .content
+                .to_string(),
             "Hello, world!"
         );
 
@@ -242,7 +248,7 @@ mod tests {
     #[test]
     fn test_into_response_message() {
         assert_eq!(
-            RESPONSE
+            create_response()
                 .into_response_message()
                 .unwrap()
                 .message
@@ -265,7 +271,7 @@ mod tests {
     #[test]
     fn test_response_message() {
         assert_eq!(
-            RESPONSE
+            create_response()
                 .response_message()
                 .unwrap()
                 .message
@@ -288,7 +294,7 @@ mod tests {
     #[test]
     fn test_unwrap_response_message() {
         assert_eq!(
-            RESPONSE
+            create_response()
                 .unwrap_response_message()
                 .message
                 .content

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -396,14 +396,14 @@ pub(crate) mod tests {
                     cache_control,
                 } = content_block
                 {
-                    assert_eq!(text, "");
+                    assert_eq!(text.as_ref(), "");
                     assert!(cache_control.is_none());
                 } else {
                     panic!("Unexpected content block: {:?}", content_block);
                 }
                 #[cfg(not(feature = "prompt-caching"))]
                 if let Block::Text { text } = content_block {
-                    assert_eq!(text, "");
+                    assert_eq!(text.as_ref(), "");
                 } else {
                     panic!("Unexpected content block: {:?}", content_block);
                 }


### PR DESCRIPTION
Feature is on by default. Anthropic does not consider this a concern, but I do.

- Addresses hidden unicode text.
- Language model will see `[X BYTES SANITIZED]` where text was stripped. So will humans if the language model genrates anything.

This breaks some const constructors so is a minor revision. Const constructors *might* return in the future with const sanitization.