### PR TITLE
v0.4.1 - More conversion methods for `MultiPart` `Content`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "misanthropic"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2021"
 authors = ["Michael de Gans <michael.john.degans@gmail.com>"]
 description = "An async, ergonomic, client for Anthropic's Messages API"


### PR DESCRIPTION
This allows things like:

```rust
let message:Message = (Assistant, [
    "<thinking>blabla</thinking>",
    "Well, user, bla bla bla",
]).into();
```

Owned arrays are supported as well as slices of strings and Vec<T> where T converts to a `Block`.