### PR TITLE
v0.5.1 Patch

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "misanthropic"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2021"
 authors = ["Michael de Gans <michael.john.degans@gmail.com>"]
 description = "An async, ergonomic, client for Anthropic's Messages API"

--- a/src/client.rs
+++ b/src/client.rs
@@ -218,17 +218,8 @@ impl Client {
             })
         } else {
             // Get a single response message.
-
-            
-            let text = response.text().await?;
-
-             #[cfg(feature = "log")]
-            if !text.is_empty() {
-
-                log::debug!("received response:\n{}", text);
-            }
             Ok(crate::Response::Message {
-                message: serde_json::from_str(&text)?,
+                message: response.json().await?,
             })
         }
     }

--- a/src/client.rs
+++ b/src/client.rs
@@ -217,9 +217,12 @@ impl Client {
                 ),
             })
         } else {
+            // Get body as JSON.
+            let body = response.bytes().await?;
+
             // Get a single response message.
             Ok(crate::Response::Message {
-                message: response.json().await?,
+                message: serde_json::from_slice(&body)?,
             })
         }
     }

--- a/src/client.rs
+++ b/src/client.rs
@@ -218,8 +218,17 @@ impl Client {
             })
         } else {
             // Get a single response message.
+
+            
+            let text = response.text().await?;
+
+             #[cfg(feature = "log")]
+            if !text.is_empty() {
+
+                log::debug!("received response:\n{}", text);
+            }
             Ok(crate::Response::Message {
-                message: response.json().await?,
+                message: serde_json::from_str(&text)?,
             })
         }
     }

--- a/src/model.rs
+++ b/src/model.rs
@@ -15,26 +15,42 @@ use serde::{Deserialize, Serialize};
     Ord,
 )]
 #[serde(rename_all = "snake_case")]
+// API reports; unknown variant `blabla`, expected one of
+// * `claude-3-5-sonnet-latest`,
+// * `claude-3-5-sonnet-20240620`,
+// * `claude-3-sonnet-20241022`,
+// * `claude-3-opus-latest`,
+// * `claude-3-opus-20240229`,
+// * `claude-3-sonnet-20240229`,
+// * `claude-3-5-haiku-latest`,
+// * `claude-3-5-haiku-20241022`,
+// * `claude-3-haiku-20240307`,
+// * `claude-3-haiku-latest`
+//
+// But docs say that `claude-3-5-sonnet-20241022` is a valid model, and the API
+// does accept it. This appears to be a bug in the API. - mdegans
+// https://docs.anthropic.com/en/docs/about-claude/models
+//
+// These does not exist at least for my API key. Last tried 11/27/2021.
+// Anthropic(NotFound { message: "model: claude-3-haiku-latest" })
+// - mdegans
 pub enum Model {
     /// Sonnet 3.5 (latest)
-    #[serde(rename = "claude-3-5-sonnet-latest")] 
-    Sonnet35, 
+    #[serde(rename = "claude-3-5-sonnet-latest")]
+    Sonnet35,
     /// Sonnet 3.5 2024-06-20
     #[serde(rename = "claude-3-5-sonnet-20240620")]
     Sonnet35_20240620,
     /// Sonnet 3.5 2024-10-22
-    #[serde(rename = "claude-3-5-sonnet-20241022")] 
-    Sonnet35_20241022, 
-    /// Sonnet 3.0 2024-10-22
-    #[serde(rename = "claude-3-sonnet-20241022")]
-    Sonnet30_20241022,
+    #[serde(rename = "claude-3-5-sonnet-20241022")]
+    Sonnet35_20241022,
     /// Opus 3.0 (latest)
     #[serde(rename = "claude-3-opus-latest")]
     Opus30,
     /// Opus 3.0 2024-02-29
     #[serde(rename = "claude-3-opus-20240229")]
     Opus30_20240229,
-    /// Sonnet 3.0
+    /// Sonnet 3.0 2024-02-29
     #[serde(rename = "claude-3-sonnet-20240229")]
     Sonnet30,
     /// Haiku 3.5 (latest)
@@ -44,13 +60,72 @@ pub enum Model {
     #[serde(rename = "claude-3-5-haiku-20241022")]
     Haiku35_20241022,
     /// Haiku 3.0 (latest) This is the default model.
-    // Note: The `latest` tag is not yet supported by the API for Haiku 3.0, so
-    // in the future this might point to a separate model. We can't use the same
-    // serde tag for both, so there's only one option here for now.
+    // Note: It is documented that the `-latest` tag works, but last I tried it
+    // the API rejected it. Last tried 11/27/2021.
+    // Anthropic(NotFound { message: "model: claude-3-haiku-latest" })
     #[default]
     #[serde(
         rename = "claude-3-haiku-20240307",
         alias = "claude-3-haiku-latest"
     )]
     Haiku30,
+}
+
+impl Model {
+    /// All available models.
+    pub const ALL: &'static [Model] = &[
+        Model::Sonnet35,
+        Model::Sonnet35_20240620,
+        Model::Sonnet35_20241022,
+        Model::Opus30,
+        Model::Opus30_20240229,
+        Model::Sonnet30,
+        Model::Haiku35,
+        Model::Haiku35_20241022,
+        Model::Haiku30,
+    ];
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{prompt::message::Role, Client, Prompt};
+
+    const CRATE_ROOT: &str = env!("CARGO_MANIFEST_DIR");
+
+    fn load_api_key() -> Option<String> {
+        use std::fs::File;
+        use std::io::Read;
+        use std::path::Path;
+
+        let mut file =
+            File::open(Path::new(CRATE_ROOT).join("api.key")).ok()?;
+        let mut key = String::new();
+        file.read_to_string(&mut key).unwrap();
+        Some(key.trim().to_string())
+    }
+
+    #[tokio::test]
+    #[ignore = "This test requires a real API key."]
+    async fn test_models_are_valid() {
+        let key = load_api_key().expect("API key not found");
+        let client = Client::new(key).unwrap();
+
+        let mut prompt = Prompt::default()
+            .add_message((Role::User, "Respond with just the parrot emoji."));
+
+        for &model in Model::ALL {
+            prompt.model = model;
+
+            // We don't actually care about the response, just that the API
+            // doesn't error out.
+            let response = client.message(&prompt).await.unwrap();
+
+            // if the mode is not a latest tag, we want to check it matches
+            // the model we set.
+            if !serde_json::to_string(&model).unwrap().contains("latest") {
+                assert_eq!(response.model, model);
+            }
+        }
+    }
 }

--- a/src/model.rs
+++ b/src/model.rs
@@ -17,11 +17,14 @@ use serde::{Deserialize, Serialize};
 #[serde(rename_all = "snake_case")]
 pub enum Model {
     /// Sonnet 3.5 (latest)
-    #[serde(rename = "claude-3-5-sonnet-latest")]
-    Sonnet35,
+    #[serde(rename = "claude-3-5-sonnet-latest")] 
+    Sonnet35, 
     /// Sonnet 3.5 2024-06-20
     #[serde(rename = "claude-3-5-sonnet-20240620")]
     Sonnet35_20240620,
+    /// Sonnet 3.5 2024-10-22
+    #[serde(rename = "claude-3-5-sonnet-20241022")] 
+    Sonnet35_20241022, 
     /// Sonnet 3.0 2024-10-22
     #[serde(rename = "claude-3-sonnet-20241022")]
     Sonnet30_20241022,

--- a/src/model.rs
+++ b/src/model.rs
@@ -117,11 +117,12 @@ mod tests {
         for &model in Model::ALL {
             prompt.model = model;
 
-            // We don't actually care about the response, just that the API
-            // doesn't error out.
+            // If this fails (because a new model was added), it should be added
+            // to the list of models above and the `latest` aliases should be
+            // updated.
             let response = client.message(&prompt).await.unwrap();
 
-            // if the mode is not a latest tag, we want to check it matches
+            // If the mode is not a latest tag, we want to check it matches
             // the model we set.
             if !serde_json::to_string(&model).unwrap().contains("latest") {
                 assert_eq!(response.model, model);

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -223,7 +223,7 @@ pub struct Stream<'a> {
 
 static_assertions::assert_impl_all!(Stream<'_>: futures::Stream, Send);
 
-impl<'a> Stream<'a> {
+impl Stream<'_> {
     /// Create a new stream from an [`eventsource_stream::EventStream`] or
     /// similar stream of [`eventsource_stream::Event`]s.
     pub fn new<S>(stream: S) -> Self

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -359,7 +359,7 @@ pub(crate) mod tests {
     /// Creates a mock stream from a string (likely `include_str!`). The string
     /// should be a series of `event`, `data`, and empty lines (a SSE stream).
     /// Anthropic provides such example data in the API documentation.
-    pub fn mock_stream(text: &'static str) -> Stream {
+    pub fn mock_stream(text: &'static str) -> Stream<'static> {
         use itertools::Itertools;
 
         // TODO: one of every possible variants, even if it doesn't make sense.


### PR DESCRIPTION
* Patch by @dr3s fixing an incorrect `Model`
* `model.rs` test coverage to ensure:
  * Every model is valid
  * If a new `latest` alias is added, the test will break and we will know about it

A bug has been confirmed in the API itself where at least one model (`claude-3-5-sonnet-20241022`) works but is undocumented and one documented model, (`claude-3-haiku-latest`) does not actually work, however our deserialization does have an alias for this for now.