### PR TITLE
fix(batch): Fix result parsing — custom_id + BatchResult deserialization

### DIFF
--- a/misanthropic/src/batch.rs
+++ b/misanthropic/src/batch.rs
@@ -635,15 +635,25 @@ impl<'a> Ready<'a> {
     }
 }
 
-/// Helper for deserializing in the format the API expects.
+/// Helper for deserializing batch results from the API's JSONL format.
+///
+/// Uses `'static` lifetime because batch results are deserialized from
+/// owned `serde_json::Value` data (the JSONL response is downloaded as a
+/// String and parsed via Value intermediate to avoid borrow issues).
 #[derive(Deserialize)]
-pub(crate) struct IdentifiedBatchResult<'a> {
+pub(crate) struct IdentifiedBatchResult {
+    #[serde(rename = "custom_id")]
     pub(crate) id: Id,
-    pub(crate) result: BatchResult<'a>,
+    pub(crate) result: BatchResult<'static>,
 }
 
 /// A [`BatchResult`] is the result of processing a [`Prompt`] in a batch.
-#[derive(Serialize, Deserialize, derive_more::IsVariant)]
+///
+/// The API returns different content keys per variant:
+/// - `succeeded` → `{ "type": "succeeded", "message": { ... } }`
+/// - `errored` → `{ "type": "errored", "error": { ... } }`
+/// - `canceled` / `expired` → `{ "type": "canceled" }` (no content)
+#[derive(Serialize, derive_more::IsVariant)]
 #[serde(rename_all = "snake_case", tag = "type")]
 pub enum BatchResult<'a> {
     /// The batch was canceled and this prompt was not processed.
@@ -654,7 +664,47 @@ pub enum BatchResult<'a> {
     #[serde(rename = "succeeded")]
     Ok(response::Message<'a>),
     /// Error response to a prompt.
+    #[serde(rename = "errored")]
     Error(client::AnthropicError),
+}
+
+impl<'de, 'a> Deserialize<'de> for BatchResult<'a> {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        // Use Value as intermediate to avoid lifetime issues with borrowed data
+        let value = serde_json::Value::deserialize(deserializer)?;
+        let type_str = value
+            .get("type")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| serde::de::Error::missing_field("type"))?;
+
+        match type_str {
+            "succeeded" => {
+                let message = value
+                    .get("message")
+                    .ok_or_else(|| serde::de::Error::missing_field("message"))?;
+                let msg: response::Message<'a> =
+                    serde_json::from_value(message.clone()).map_err(serde::de::Error::custom)?;
+                Ok(BatchResult::Ok(msg))
+            }
+            "errored" => {
+                let error = value
+                    .get("error")
+                    .ok_or_else(|| serde::de::Error::missing_field("error"))?;
+                let err: client::AnthropicError =
+                    serde_json::from_value(error.clone()).map_err(serde::de::Error::custom)?;
+                Ok(BatchResult::Error(err))
+            }
+            "canceled" => Ok(BatchResult::Canceled),
+            "expired" => Ok(BatchResult::Expired),
+            other => Err(serde::de::Error::unknown_variant(
+                other,
+                &["succeeded", "errored", "canceled", "expired"],
+            )),
+        }
+    }
 }
 
 impl<'a> From<BatchResult<'a>>

--- a/misanthropic/src/client.rs
+++ b/misanthropic/src/client.rs
@@ -561,7 +561,9 @@ impl Client {
             let mut results = HashMap::new();
 
             for line in response.lines() {
-                match serde_json::from_str(line) {
+                match serde_json::from_str::<serde_json::Value>(line)
+                    .and_then(|v| serde_json::from_value::<IdentifiedBatchResult>(v))
+                {
                     Ok(IdentifiedBatchResult { id, result }) => {
                         // We do need to check for this to maintain the Ready
                         // invariant that every result has a corresponding


### PR DESCRIPTION
## Summary

- Fix `IdentifiedBatchResult` field name: API returns `custom_id`, not `id`
- Replace derived `BatchResult` `Deserialize` with custom impl that handles the API's variant-specific content keys (`message` for succeeded, `error` for errored)
- Fix lifetime issue: deserialize via `serde_json::Value` intermediate so batch results are owned (`'static`), avoiding borrow-from-local-variable error in `batch_poll`

## Context

Discovered while testing Agora's appeals pipeline. The Tier 2 review batch (24 Haiku prompts) submitted and completed successfully on Anthropic's side, but `Ready::into_iter()` returned zero results because every JSONL line failed to parse silently.

## Test plan

- [x] `cargo test -p misanthropic --features batch --lib` — 150 passed, 0 failed
- [ ] Integration test with real batch API (confirmed working in Agora's appeals pipeline)

🤖 Generated with [Claude Code](https://claude.com/claude-code)