### PR TITLE
feat: Remove prompt-caching gate, add OpenAI conversion module

### DIFF
--- a/chat/frontend/Cargo.toml
+++ b/chat/frontend/Cargo.toml
@@ -20,7 +20,6 @@ misanthropic = { path = "../../misanthropic", default-features = false, features
     "dioxus",
     "html",
     "notepad",
-    "prompt-caching",
 ] }
 uuid = { version = "0.8", features = ["v4"], default-features = false }
 getrandom = { version = "0.2", features = ["js"], default-features = false }

--- a/misanthropic/Cargo.toml
+++ b/misanthropic/Cargo.toml
@@ -129,9 +129,6 @@ default = ["rustls-tls", "langsan", "rate-limiting", "client", "batch"]
 # you must handle encoding/decoding yourself, so it almost always makes sense
 # to enable this and use the image crate.
 image = ["dep:image"]
-# A beta has been enabled. It is not necessary to set this manually. Only one
-# beta can be enabled at a time (for example, `prompt-caching`).
-beta = []
 # Use the image crate to support JPEG images.
 jpeg = ["image", "image/jpeg"]
 # Use the image crate to support PNG images.
@@ -140,8 +137,6 @@ png = ["image", "image/png"]
 gif = ["image", "image/gif"]
 # Use the image crate to support WEBP images.
 webp = ["image", "image/webp"]
-# Enable prompt caching (recommended, however limits model choices)
-prompt-caching = ["beta"]
 # Enable logging
 log = ["dep:log"]
 # Use rustls instead of the system SSL, such as OpenSSL.
@@ -182,6 +177,9 @@ sqlx = ["dep:sqlx"]
 tokio-sqlx = ["sqlx/runtime-tokio-rustls"]
 # Feature for testing with in-memory database
 kv-mem = []
+# OpenAI-compatible types and conversions for use with Ollama and other
+# OpenAI-compatible endpoints.
+openai = []
 
 
 [[example]]
@@ -191,7 +189,7 @@ doc-scrape-examples = true
 
 [[example]]
 name = "python"
-required-features = ["client", "markdown", "prompt-caching"]
+required-features = ["client", "markdown"]
 doc-scrape-examples = true
 
 [[example]]

--- a/misanthropic/examples/python.rs
+++ b/misanthropic/examples/python.rs
@@ -117,7 +117,6 @@ pub fn handle_tool_call(
                     tool_use_id: call.id.to_string().into(),
                     content: output.into(),
                     is_error: false,
-                    #[cfg(feature = "prompt-caching")]
                     cache_control: None,
                 }
                 .into());
@@ -133,7 +132,6 @@ pub fn handle_tool_call(
                     tool_use_id: call.id.to_string().into(),
                     content: output.into(),
                     is_error: true,
-                    #[cfg(feature = "prompt-caching")]
                     cache_control: None,
                 }
                 .into());
@@ -144,7 +142,6 @@ pub fn handle_tool_call(
                 tool_use_id: call.id.to_string().into(),
                 content: "Python script timed out.".into(),
                 is_error: true,
-                #[cfg(feature = "prompt-caching")]
                 cache_control: None,
             }
             .into());
@@ -155,7 +152,6 @@ pub fn handle_tool_call(
             tool_use_id: call.id.to_string().into(),
             content: "Invalid input.".into(),
             is_error: true,
-            #[cfg(feature = "prompt-caching")]
             cache_control: None,
         }
         .into())
@@ -207,7 +203,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 },
                 "required": ["script"],
             }),
-            #[cfg(feature = "prompt-caching")]
             cache_control: None,
         })
         // Inform the assistant about their limitations.
@@ -248,7 +243,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 tool_use_id: "calibration_000".into(),
                 content: "3".into(),
                 is_error: false,
-                #[cfg(feature = "prompt-caching")]
                 cache_control: None,
             }.into(),
             (Role::Assistant, r#"The number of r's in "strawberry" is 3.""#).into(),

--- a/misanthropic/examples/strawberry.rs
+++ b/misanthropic/examples/strawberry.rs
@@ -59,7 +59,6 @@ pub fn handle_tool_call(call: &tool::Use) -> Result<Message<'static>, String> {
             tool_use_id: call.id.to_string().into(),
             content: count.to_string().into(),
             is_error: false,
-            #[cfg(feature = "prompt-caching")]
             cache_control: None,
         }
         // A `tool::Result` is always convertable to a `Message`. The `Role` is
@@ -105,7 +104,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             },
             "required": ["letter", "string"],
         }),
-        #[cfg(feature = "prompt-caching")]
         cache_control: None,
     // Inform the assistant about their limitations.
     }).set_system("You are a helpful assistant. You cannot count letters in a word by yourself because you see in tokens, not letters. Use the `count_letters` tool to overcome this limitation.")

--- a/misanthropic/src/batch.rs
+++ b/misanthropic/src/batch.rs
@@ -682,11 +682,12 @@ impl<'de, 'a> Deserialize<'de> for BatchResult<'a> {
 
         match type_str {
             "succeeded" => {
-                let message = value
-                    .get("message")
-                    .ok_or_else(|| serde::de::Error::missing_field("message"))?;
+                let message = value.get("message").ok_or_else(|| {
+                    serde::de::Error::missing_field("message")
+                })?;
                 let msg: response::Message<'a> =
-                    serde_json::from_value(message.clone()).map_err(serde::de::Error::custom)?;
+                    serde_json::from_value(message.clone())
+                        .map_err(serde::de::Error::custom)?;
                 Ok(BatchResult::Ok(msg))
             }
             "errored" => {
@@ -694,7 +695,8 @@ impl<'de, 'a> Deserialize<'de> for BatchResult<'a> {
                     .get("error")
                     .ok_or_else(|| serde::de::Error::missing_field("error"))?;
                 let err: client::AnthropicError =
-                    serde_json::from_value(error.clone()).map_err(serde::de::Error::custom)?;
+                    serde_json::from_value(error.clone())
+                        .map_err(serde::de::Error::custom)?;
                 Ok(BatchResult::Error(err))
             }
             "canceled" => Ok(BatchResult::Canceled),

--- a/misanthropic/src/client.rs
+++ b/misanthropic/src/client.rs
@@ -67,15 +67,12 @@ pub struct Client {
     pub models_url: Arc<Url>,
 }
 
-/// Claude client. Uses the Messages API and the prompt caching beta.
+/// Claude client. Uses the Messages API.
 #[cfg(feature = "client")]
 impl Client {
     /// Version of the API. This is appended to the header as
     /// "anthropic-version".
     pub const ANTHROPIC_VERSION: &'static str = "2023-06-01";
-    /// Beta we are using. This is appended to the header as "anthropic-beta".
-    #[cfg(feature = "prompt-caching")]
-    pub const BETA: &'static str = "prompt-caching-2024-07-31";
     /// Our user agent.
     pub const USER_AGENT: &'static str =
         concat!(env!("CARGO_PKG_NAME"), "-", env!("CARGO_PKG_VERSION"));
@@ -113,8 +110,6 @@ impl Client {
             ));
             log::debug!(concat!("Crate version: ", env!("CARGO_PKG_VERSION")));
             log::debug!("Anthropic version: {}", Self::ANTHROPIC_VERSION);
-            #[cfg(feature = "beta")]
-            log::debug!("Anthropic beta: {}", Self::BETA);
         }
 
         // Headers for all requests.
@@ -130,13 +125,6 @@ impl Client {
         headers.insert(
             "anthropic-version",
             reqwest::header::HeaderValue::from_static(Self::ANTHROPIC_VERSION),
-        );
-
-        // Enable prompt caching beta.
-        #[cfg(feature = "prompt-caching")]
-        headers.insert(
-            "anthropic-beta",
-            reqwest::header::HeaderValue::from_static(Self::BETA),
         );
 
         Self {
@@ -561,9 +549,9 @@ impl Client {
             let mut results = HashMap::new();
 
             for line in response.lines() {
-                match serde_json::from_str::<serde_json::Value>(line)
-                    .and_then(|v| serde_json::from_value::<IdentifiedBatchResult>(v))
-                {
+                match serde_json::from_str::<serde_json::Value>(line).and_then(
+                    |v| serde_json::from_value::<IdentifiedBatchResult>(v),
+                ) {
                     Ok(IdentifiedBatchResult { id, result }) => {
                         // We do need to check for this to maintain the Ready
                         // invariant that every result has a corresponding

--- a/misanthropic/src/cot.rs
+++ b/misanthropic/src/cot.rs
@@ -416,7 +416,6 @@ mod tests {
                 tool_use_id: "blablak".into(),
                 content: "blabla".into(),
                 is_error: false,
-                #[cfg(feature = "prompt-caching")]
                 cache_control: None,
             },
         };

--- a/misanthropic/src/html.rs
+++ b/misanthropic/src/html.rs
@@ -221,7 +221,6 @@ mod tests {
                     },
                     "required": ["script"],
                 }),
-                #[cfg(feature = "prompt-caching")]
                 cache_control: None,
             }]),
             messages: vec![
@@ -235,7 +234,6 @@ mod tests {
                     input: json!({
                         "script": "print('Hello, world!')",
                     }),
-                    #[cfg(feature = "prompt-caching")]
                     cache_control: None,
                 }
                 .into(),
@@ -247,7 +245,6 @@ mod tests {
                     .to_string()
                     .into(),
                     is_error: false,
-                    #[cfg(feature = "prompt-caching")]
                     cache_control: None,
                 }
                 .into(),

--- a/misanthropic/src/lib.rs
+++ b/misanthropic/src/lib.rs
@@ -52,6 +52,12 @@ pub mod html;
 #[cfg(feature = "cot")]
 pub mod cot;
 
+#[cfg(feature = "openai")]
+#[allow(missing_docs)]
+/// OpenAI-compatible types and conversions for use with Ollama and other
+/// OpenAI-compatible endpoints.
+pub mod openai;
+
 #[cfg(not(feature = "langsan"))]
 pub(crate) type CowStr<'a> = std::borrow::Cow<'a, str>;
 #[cfg(feature = "langsan")]

--- a/misanthropic/src/openai.rs
+++ b/misanthropic/src/openai.rs
@@ -1,0 +1,1062 @@
+//! OpenAI-compatible types and conversion from [misanthropic] primitives.
+//!
+//! This module provides types matching the [OpenAI Chat Completions API],
+//! and conversion impls to translate [`Prompt`], [`Message`], and tool types
+//! between the Anthropic and OpenAI formats. This enables using misanthropic
+//! as the canonical representation for prompts, then serializing to either
+//! the Anthropic Messages API or OpenAI-compatible endpoints (like [Ollama]).
+//!
+//! # Feature
+//!
+//! This module is gated behind the `openai` feature:
+//!
+//! ```toml
+//! misanthropic = { version = "1", features = ["openai"] }
+//! ```
+//!
+//! [OpenAI Chat Completions API]: https://platform.openai.com/docs/api-reference/chat
+//! [Ollama]: https://ollama.com/blog/openai-compatibility
+//! [`Prompt`]: crate::Prompt
+//! [`Message`]: crate::prompt::Message
+
+use std::borrow::Cow;
+
+use serde::{Deserialize, Serialize};
+
+use crate::CowStr;
+use crate::Prompt;
+use crate::prompt::Message;
+use crate::prompt::message::{Block, Content, Image, MediaType, Role};
+use crate::tool;
+
+// ---------------------------------------------------------------------------
+// Request types
+// ---------------------------------------------------------------------------
+
+/// An OpenAI-compatible chat completion request.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ChatCompletionRequest {
+    /// Model identifier (e.g. `"gpt-4"`, `"cogito:14b"`).
+    pub model: String,
+    /// The conversation messages.
+    pub messages: Vec<ChatMessage>,
+    /// Tool definitions available to the model.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tools: Option<Vec<ChatTool>>,
+    /// How the model should choose which tool to call.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tool_choice: Option<ChatToolChoice>,
+    /// Sampling temperature (0.0–2.0).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub temperature: Option<f32>,
+    /// Maximum tokens to generate.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub max_tokens: Option<u32>,
+    /// Nucleus sampling parameter.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub top_p: Option<f32>,
+    /// Stop sequences.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub stop: Option<Vec<String>>,
+    /// Whether to stream the response.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub stream: Option<bool>,
+}
+
+/// A message in the chat completions format.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ChatMessage {
+    pub role: ChatRole,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub content: Option<ChatContent>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tool_calls: Option<Vec<ChatToolCall>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tool_call_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+}
+
+/// Role in the OpenAI chat format.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum ChatRole {
+    System,
+    User,
+    Assistant,
+    Tool,
+}
+
+/// Content can be a plain string or an array of content parts (for images).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum ChatContent {
+    /// Plain text content.
+    Text(String),
+    /// Array of content parts (text + images).
+    Parts(Vec<ChatContentPart>),
+}
+
+/// A content part in a multi-part message.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum ChatContentPart {
+    /// Text content part.
+    Text { text: String },
+    /// Image URL content part (supports `data:` URIs for inline images).
+    ImageUrl { image_url: ImageUrl },
+}
+
+/// An image URL reference.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ImageUrl {
+    /// URL or `data:image/{format};base64,{data}` for inline images.
+    pub url: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub detail: Option<String>,
+}
+
+// ---------------------------------------------------------------------------
+// Tool types
+// ---------------------------------------------------------------------------
+
+/// An OpenAI-compatible tool definition.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ChatTool {
+    #[serde(rename = "type")]
+    pub kind: String,
+    pub function: ChatFunction,
+}
+
+/// A function definition within a tool.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ChatFunction {
+    pub name: String,
+    pub description: String,
+    pub parameters: serde_json::Value,
+}
+
+/// Tool choice constraint.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum ChatToolChoice {
+    /// A string like "auto", "none", or "required".
+    String(String),
+    /// A specific function choice.
+    Object {
+        #[serde(rename = "type")]
+        kind: String,
+        function: ChatToolChoiceFunction,
+    },
+}
+
+/// Specifies a particular function for tool choice.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ChatToolChoiceFunction {
+    pub name: String,
+}
+
+/// A tool call from the assistant.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ChatToolCall {
+    pub id: String,
+    #[serde(rename = "type")]
+    pub kind: String,
+    pub function: ChatFunctionCall,
+}
+
+/// A function call within a tool call.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ChatFunctionCall {
+    pub name: String,
+    /// JSON-encoded arguments string.
+    pub arguments: String,
+}
+
+// ---------------------------------------------------------------------------
+// Response types
+// ---------------------------------------------------------------------------
+
+/// An OpenAI-compatible chat completion response.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ChatCompletionResponse {
+    #[serde(default)]
+    pub id: String,
+    pub choices: Vec<ChatChoice>,
+    #[serde(default)]
+    pub model: String,
+    #[serde(default)]
+    pub usage: Option<ChatUsage>,
+}
+
+/// A choice in the response.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ChatChoice {
+    #[serde(default)]
+    pub index: u32,
+    pub message: ChatMessage,
+    #[serde(default)]
+    pub finish_reason: Option<String>,
+}
+
+/// Token usage statistics.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ChatUsage {
+    #[serde(default)]
+    pub prompt_tokens: u32,
+    #[serde(default)]
+    pub completion_tokens: u32,
+    #[serde(default)]
+    pub total_tokens: u32,
+}
+
+// ---------------------------------------------------------------------------
+// Streaming types
+// ---------------------------------------------------------------------------
+
+/// A streaming chunk from the chat completions API.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ChatCompletionChunk {
+    #[serde(default)]
+    pub id: String,
+    pub choices: Vec<ChatChunkChoice>,
+    #[serde(default)]
+    pub model: String,
+    #[serde(default)]
+    pub usage: Option<ChatUsage>,
+}
+
+/// A choice within a streaming chunk.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ChatChunkChoice {
+    #[serde(default)]
+    pub index: u32,
+    pub delta: ChatDelta,
+    #[serde(default)]
+    pub finish_reason: Option<String>,
+}
+
+/// Delta content in a streaming chunk.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct ChatDelta {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub role: Option<ChatRole>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub content: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tool_calls: Option<Vec<ChatToolCallDelta>>,
+}
+
+/// A partial tool call in a streaming delta.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ChatToolCallDelta {
+    pub index: u32,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub id: Option<String>,
+    #[serde(rename = "type", skip_serializing_if = "Option::is_none")]
+    pub kind: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub function: Option<ChatFunctionCallDelta>,
+}
+
+/// Partial function call data in a streaming delta.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ChatFunctionCallDelta {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub arguments: Option<String>,
+}
+
+// ---------------------------------------------------------------------------
+// Accumulator for streaming chunks
+// ---------------------------------------------------------------------------
+
+/// Accumulates streaming [`ChatCompletionChunk`]s into a complete
+/// [`Message`].
+///
+/// Feed chunks via [`process_chunk`] and call [`into_message`] when the
+/// stream is done.
+///
+/// [`process_chunk`]: ChatStreamAccumulator::process_chunk
+/// [`into_message`]: ChatStreamAccumulator::into_message
+#[derive(Debug, Default)]
+pub struct ChatStreamAccumulator {
+    content: String,
+    tool_calls: Vec<AccumulatedToolCall>,
+    finish_reason: Option<String>,
+}
+
+#[derive(Debug, Default)]
+struct AccumulatedToolCall {
+    id: String,
+    name: String,
+    arguments: String,
+}
+
+impl ChatStreamAccumulator {
+    /// Create a new empty accumulator.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Process a streaming chunk, accumulating its content.
+    pub fn process_chunk(&mut self, chunk: ChatCompletionChunk) {
+        for choice in chunk.choices {
+            if let Some(reason) = choice.finish_reason {
+                self.finish_reason = Some(reason);
+            }
+
+            let delta = choice.delta;
+
+            if let Some(text) = delta.content {
+                self.content.push_str(&text);
+            }
+
+            if let Some(calls) = delta.tool_calls {
+                for call_delta in calls {
+                    let idx = call_delta.index as usize;
+
+                    // Extend the vec if needed
+                    while self.tool_calls.len() <= idx {
+                        self.tool_calls.push(AccumulatedToolCall::default());
+                    }
+
+                    let acc = &mut self.tool_calls[idx];
+
+                    if let Some(id) = call_delta.id {
+                        acc.id = id;
+                    }
+                    if let Some(func) = call_delta.function {
+                        if let Some(name) = func.name {
+                            acc.name = name;
+                        }
+                        if let Some(args) = func.arguments {
+                            acc.arguments.push_str(&args);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    /// The finish reason from the final chunk, if received.
+    pub fn finish_reason(&self) -> Option<&str> {
+        self.finish_reason.as_deref()
+    }
+
+    /// Consume the accumulator and produce a misanthropic [`Message`].
+    ///
+    /// Returns `None` if no content or tool calls were accumulated.
+    pub fn into_message(self) -> Option<Message<'static>> {
+        let has_content = !self.content.is_empty();
+        let has_tools = !self.tool_calls.is_empty();
+
+        if !has_content && !has_tools {
+            return None;
+        }
+
+        let mut blocks: Vec<Block<'static>> = Vec::new();
+
+        if has_content {
+            blocks.push(Block::Text {
+                text: CowStr::from(self.content),
+                cache_control: None,
+            });
+        }
+
+        for call in self.tool_calls {
+            let input: serde_json::Value =
+                serde_json::from_str(&call.arguments)
+                    .unwrap_or(serde_json::Value::Null);
+            blocks.push(Block::ToolUse {
+                call: tool::Use {
+                    id: Cow::Owned(call.id),
+                    name: Cow::Owned(call.name),
+                    input,
+                    cache_control: None,
+                },
+            });
+        }
+
+        Some(Message {
+            role: Role::Assistant,
+            content: Content::MultiPart(blocks),
+        })
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Conversions: misanthropic → OpenAI
+// ---------------------------------------------------------------------------
+
+impl<'a> From<&Prompt<'a>> for ChatCompletionRequest {
+    fn from(prompt: &Prompt<'a>) -> Self {
+        let mut messages = Vec::new();
+
+        // System message
+        if let Some(system) = &prompt.system {
+            messages.push(ChatMessage {
+                role: ChatRole::System,
+                content: Some(ChatContent::Text(content_to_text(system))),
+                tool_calls: None,
+                tool_call_id: None,
+                name: None,
+            });
+        }
+
+        // Conversation messages
+        for msg in &prompt.messages {
+            messages.extend(message_to_chat_messages(msg));
+        }
+
+        // Tools
+        let tools = prompt
+            .functions
+            .as_ref()
+            .map(|methods| methods.iter().map(ChatTool::from).collect());
+
+        // Tool choice
+        let tool_choice =
+            prompt.tool_choice.as_ref().map(|choice| match choice {
+                tool::Choice::Auto => {
+                    ChatToolChoice::String("auto".to_string())
+                }
+                tool::Choice::Any => {
+                    ChatToolChoice::String("required".to_string())
+                }
+                tool::Choice::Method { name } => ChatToolChoice::Object {
+                    kind: "function".to_string(),
+                    function: ChatToolChoiceFunction { name: name.clone() },
+                },
+            });
+
+        ChatCompletionRequest {
+            model: prompt.model.to_string(),
+            messages,
+            tools,
+            tool_choice,
+            temperature: prompt.temperature,
+            max_tokens: prompt.max_tokens.get().try_into().ok(),
+            top_p: prompt.top_p,
+            stop: prompt
+                .stop_sequences
+                .as_ref()
+                .map(|seqs| seqs.iter().map(|s| s.to_string()).collect()),
+            stream: prompt.stream,
+        }
+    }
+}
+
+impl<'a> From<&tool::Method<'a>> for ChatTool {
+    fn from(method: &tool::Method<'a>) -> Self {
+        ChatTool {
+            kind: "function".to_string(),
+            function: ChatFunction {
+                name: method.name.to_string(),
+                description: method.description.to_string(),
+                parameters: method.schema.clone(),
+            },
+        }
+    }
+}
+
+impl From<ChatToolCall> for tool::Use<'static> {
+    fn from(call: ChatToolCall) -> Self {
+        let input: serde_json::Value =
+            serde_json::from_str(&call.function.arguments)
+                .unwrap_or(serde_json::Value::Null);
+        tool::Use {
+            id: Cow::Owned(call.id),
+            name: Cow::Owned(call.function.name),
+            input,
+            cache_control: None,
+        }
+    }
+}
+
+impl<'a> From<&tool::Result<'a>> for ChatMessage {
+    fn from(result: &tool::Result<'a>) -> Self {
+        ChatMessage {
+            role: ChatRole::Tool,
+            content: Some(ChatContent::Text(content_to_text(&result.content))),
+            tool_calls: None,
+            tool_call_id: Some(result.tool_use_id.to_string()),
+            name: None,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Conversions: OpenAI → misanthropic
+// ---------------------------------------------------------------------------
+
+impl ChatCompletionResponse {
+    /// Extract the first choice's message as a misanthropic [`Message`].
+    ///
+    /// Returns `None` if no choices are present.
+    pub fn into_message(self) -> Option<Message<'static>> {
+        let choice = self.choices.into_iter().next()?;
+        Some(chat_message_to_message(choice.message))
+    }
+
+    /// The finish reason from the first choice.
+    pub fn finish_reason(&self) -> Option<&str> {
+        self.choices
+            .first()
+            .and_then(|c| c.finish_reason.as_deref())
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+/// Extract the text content from a misanthropic [`Content`], ignoring
+/// non-text blocks.
+fn content_to_text(content: &Content<'_>) -> String {
+    match content {
+        Content::SinglePart(text) => text.to_string(),
+        Content::MultiPart(blocks) => {
+            let mut out = String::new();
+            for block in blocks {
+                if let Block::Text { text, .. } = block {
+                    if !out.is_empty() {
+                        out.push('\n');
+                    }
+                    out.push_str(text);
+                }
+            }
+            out
+        }
+    }
+}
+
+/// Convert a misanthropic [`Message`] into one or more [`ChatMessage`]s.
+///
+/// A single misanthropic message with both text and tool use/results may
+/// produce multiple OpenAI messages, because tool results must be separate
+/// messages with `role: "tool"`.
+fn message_to_chat_messages<'a>(msg: &Message<'a>) -> Vec<ChatMessage> {
+    match &msg.content {
+        Content::SinglePart(text) => vec![ChatMessage {
+            role: role_to_chat_role(msg.role),
+            content: Some(ChatContent::Text(text.to_string())),
+            tool_calls: None,
+            tool_call_id: None,
+            name: None,
+        }],
+        Content::MultiPart(blocks) => {
+            let mut text_parts = Vec::new();
+            let mut image_parts = Vec::new();
+            let mut tool_calls = Vec::new();
+            let mut tool_results = Vec::new();
+
+            for block in blocks {
+                match block {
+                    Block::Text { text, .. } => {
+                        text_parts.push(text.to_string());
+                    }
+                    Block::Image { image, .. } => {
+                        let Image::Base64 {
+                            media_type, data, ..
+                        } = image;
+                        let mt = match media_type {
+                            MediaType::Jpeg => "image/jpeg",
+                            MediaType::Png => "image/png",
+                            MediaType::Gif => "image/gif",
+                            MediaType::Webp => "image/webp",
+                        };
+                        let data_url = format!("data:{};base64,{}", mt, data);
+                        image_parts.push(ChatContentPart::ImageUrl {
+                            image_url: ImageUrl {
+                                url: data_url,
+                                detail: None,
+                            },
+                        });
+                    }
+                    Block::ToolUse { call } => {
+                        tool_calls.push(ChatToolCall {
+                            id: call.id.to_string(),
+                            kind: "function".to_string(),
+                            function: ChatFunctionCall {
+                                name: call.name.to_string(),
+                                arguments: serde_json::to_string(&call.input)
+                                    .unwrap_or_default(),
+                            },
+                        });
+                    }
+                    Block::ToolResult { result } => {
+                        tool_results.push(ChatMessage {
+                            role: ChatRole::Tool,
+                            content: Some(ChatContent::Text(content_to_text(
+                                &result.content,
+                            ))),
+                            tool_calls: None,
+                            tool_call_id: Some(result.tool_use_id.to_string()),
+                            name: None,
+                        });
+                    }
+                    // Thought blocks have no OpenAI equivalent — skip them
+                    Block::Thought { .. } | Block::RedactedThought { .. } => {}
+                }
+            }
+
+            let mut messages = Vec::new();
+
+            // Build the primary message
+            if msg.role == Role::Assistant {
+                // Assistant: text content + optional tool calls
+                let content = if text_parts.is_empty() {
+                    None
+                } else {
+                    Some(ChatContent::Text(text_parts.join("\n")))
+                };
+                let calls = if tool_calls.is_empty() {
+                    None
+                } else {
+                    Some(tool_calls)
+                };
+                messages.push(ChatMessage {
+                    role: ChatRole::Assistant,
+                    content,
+                    tool_calls: calls,
+                    tool_call_id: None,
+                    name: None,
+                });
+            } else {
+                // User: may have text + images
+                if !image_parts.is_empty() {
+                    let mut parts: Vec<ChatContentPart> = text_parts
+                        .iter()
+                        .map(|t| ChatContentPart::Text { text: t.clone() })
+                        .collect();
+                    parts.extend(image_parts);
+                    messages.push(ChatMessage {
+                        role: ChatRole::User,
+                        content: Some(ChatContent::Parts(parts)),
+                        tool_calls: None,
+                        tool_call_id: None,
+                        name: None,
+                    });
+                } else if !text_parts.is_empty() {
+                    messages.push(ChatMessage {
+                        role: role_to_chat_role(msg.role),
+                        content: Some(ChatContent::Text(text_parts.join("\n"))),
+                        tool_calls: None,
+                        tool_call_id: None,
+                        name: None,
+                    });
+                }
+            }
+
+            // Tool results become separate messages
+            messages.extend(tool_results);
+
+            messages
+        }
+    }
+}
+
+/// Convert a [`ChatMessage`] into a misanthropic [`Message`].
+fn chat_message_to_message(msg: ChatMessage) -> Message<'static> {
+    let mut blocks: Vec<Block<'static>> = Vec::new();
+
+    // Text content
+    if let Some(content) = msg.content {
+        match content {
+            ChatContent::Text(text) => {
+                if !text.is_empty() {
+                    blocks.push(Block::Text {
+                        text: CowStr::from(text),
+                        cache_control: None,
+                    });
+                }
+            }
+            ChatContent::Parts(parts) => {
+                for part in parts {
+                    match part {
+                        ChatContentPart::Text { text } => {
+                            blocks.push(Block::Text {
+                                text: CowStr::from(text),
+                                cache_control: None,
+                            });
+                        }
+                        ChatContentPart::ImageUrl { .. } => {
+                            // Image URL conversion back to base64 Block would
+                            // require parsing data: URIs — skip for now.
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // Tool calls
+    if let Some(calls) = msg.tool_calls {
+        for call in calls {
+            blocks.push(Block::ToolUse {
+                call: tool::Use::from(call),
+            });
+        }
+    }
+
+    let role = match msg.role {
+        ChatRole::Assistant => Role::Assistant,
+        _ => Role::User,
+    };
+
+    if blocks.len() == 1 {
+        if let Block::Text { text, .. } = &blocks[0] {
+            return Message {
+                role,
+                content: Content::SinglePart(text.clone()),
+            };
+        }
+    }
+
+    Message {
+        role,
+        content: if blocks.is_empty() {
+            Content::SinglePart(CowStr::from(String::new()))
+        } else {
+            Content::MultiPart(blocks)
+        },
+    }
+}
+
+fn role_to_chat_role(role: Role) -> ChatRole {
+    match role {
+        Role::User => ChatRole::User,
+        Role::Assistant => ChatRole::Assistant,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::num::NonZeroU32;
+
+    #[test]
+    fn simple_prompt_to_chat_request() {
+        let prompt = Prompt {
+            model: "claude-sonnet-4-20250514".into(),
+            messages: vec![Message {
+                role: Role::User,
+                content: Content::SinglePart("Hello".into()),
+            }],
+            max_tokens: NonZeroU32::new(1024).unwrap(),
+            system: Some(Content::SinglePart("You are helpful.".into())),
+            ..Default::default()
+        };
+
+        let req = ChatCompletionRequest::from(&prompt);
+        assert_eq!(req.model, "claude-sonnet-4-20250514");
+        assert_eq!(req.messages.len(), 2);
+        assert_eq!(req.messages[0].role, ChatRole::System);
+        assert_eq!(req.messages[1].role, ChatRole::User);
+
+        if let Some(ChatContent::Text(t)) = &req.messages[0].content {
+            assert_eq!(t, "You are helpful.");
+        } else {
+            panic!("expected text content");
+        }
+    }
+
+    #[test]
+    fn tool_method_to_chat_tool() {
+        let method = tool::Method::builder("get_weather")
+            .description("Get the weather")
+            .schema(serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "location": { "type": "string" }
+                },
+                "required": ["location"]
+            }))
+            .build()
+            .unwrap();
+
+        let chat_tool = ChatTool::from(&method);
+        assert_eq!(chat_tool.kind, "function");
+        assert_eq!(chat_tool.function.name, "get_weather");
+        assert_eq!(chat_tool.function.description, "Get the weather");
+    }
+
+    #[test]
+    fn tool_call_round_trip() {
+        let chat_call = ChatToolCall {
+            id: "call_123".to_string(),
+            kind: "function".to_string(),
+            function: ChatFunctionCall {
+                name: "get_weather".to_string(),
+                arguments: r#"{"location":"Paris"}"#.to_string(),
+            },
+        };
+
+        let use_block: tool::Use<'static> = chat_call.into();
+        assert_eq!(use_block.id, "call_123");
+        assert_eq!(use_block.name, "get_weather");
+        assert_eq!(use_block.input["location"], "Paris");
+    }
+
+    #[test]
+    fn tool_choice_mapping() {
+        let prompt = Prompt {
+            model: "test".into(),
+            messages: vec![],
+            max_tokens: NonZeroU32::new(100).unwrap(),
+            tool_choice: Some(tool::Choice::Any),
+            ..Default::default()
+        };
+
+        let req = ChatCompletionRequest::from(&prompt);
+        assert!(matches!(
+            req.tool_choice,
+            Some(ChatToolChoice::String(ref s)) if s == "required"
+        ));
+    }
+
+    #[test]
+    fn tool_result_to_chat_message() {
+        let result = tool::Result {
+            tool_use_id: Cow::Borrowed("call_456"),
+            content: Content::SinglePart("Sunny, 22°C".into()),
+            is_error: false,
+            cache_control: None,
+        };
+
+        let msg = ChatMessage::from(&result);
+        assert_eq!(msg.role, ChatRole::Tool);
+        assert_eq!(msg.tool_call_id.as_deref(), Some("call_456"));
+        if let Some(ChatContent::Text(t)) = &msg.content {
+            assert_eq!(t, "Sunny, 22°C");
+        } else {
+            panic!("expected text");
+        }
+    }
+
+    #[test]
+    fn response_into_message() {
+        let resp = ChatCompletionResponse {
+            id: "chatcmpl-123".to_string(),
+            choices: vec![ChatChoice {
+                index: 0,
+                message: ChatMessage {
+                    role: ChatRole::Assistant,
+                    content: Some(ChatContent::Text("Hello!".to_string())),
+                    tool_calls: None,
+                    tool_call_id: None,
+                    name: None,
+                },
+                finish_reason: Some("stop".to_string()),
+            }],
+            model: "gpt-4".to_string(),
+            usage: None,
+        };
+
+        let msg = resp.into_message().unwrap();
+        assert_eq!(msg.role, Role::Assistant);
+        if let Content::SinglePart(text) = &msg.content {
+            assert_eq!(text.to_string(), "Hello!");
+        } else {
+            panic!("expected single part");
+        }
+    }
+
+    #[test]
+    fn response_with_tool_calls() {
+        let resp = ChatCompletionResponse {
+            id: "chatcmpl-456".to_string(),
+            choices: vec![ChatChoice {
+                index: 0,
+                message: ChatMessage {
+                    role: ChatRole::Assistant,
+                    content: None,
+                    tool_calls: Some(vec![ChatToolCall {
+                        id: "call_789".to_string(),
+                        kind: "function".to_string(),
+                        function: ChatFunctionCall {
+                            name: "search".to_string(),
+                            arguments: r#"{"query":"rust"}"#.to_string(),
+                        },
+                    }]),
+                    tool_call_id: None,
+                    name: None,
+                },
+                finish_reason: Some("tool_calls".to_string()),
+            }],
+            model: "test".to_string(),
+            usage: None,
+        };
+
+        let msg = resp.into_message().unwrap();
+        assert_eq!(msg.role, Role::Assistant);
+        let tool_use = msg.tool_use().unwrap();
+        assert_eq!(tool_use.name, "search");
+        assert_eq!(tool_use.input["query"], "rust");
+    }
+
+    #[test]
+    fn thought_blocks_stripped() {
+        let msg = Message {
+            role: Role::Assistant,
+            content: Content::MultiPart(vec![
+                Block::Thought {
+                    thought: "thinking...".into(),
+                    signature: "sig".into(),
+                },
+                Block::Text {
+                    text: "Hello!".into(),
+                    cache_control: None,
+                },
+            ]),
+        };
+
+        let chat_msgs = message_to_chat_messages(&msg);
+        assert_eq!(chat_msgs.len(), 1);
+        if let Some(ChatContent::Text(t)) = &chat_msgs[0].content {
+            assert_eq!(t, "Hello!");
+        }
+        // No thought in the output
+    }
+
+    #[test]
+    fn stream_accumulator_text() {
+        let mut acc = ChatStreamAccumulator::new();
+
+        acc.process_chunk(ChatCompletionChunk {
+            id: "1".into(),
+            choices: vec![ChatChunkChoice {
+                index: 0,
+                delta: ChatDelta {
+                    role: Some(ChatRole::Assistant),
+                    content: Some("Hello".into()),
+                    tool_calls: None,
+                },
+                finish_reason: None,
+            }],
+            model: "test".into(),
+            usage: None,
+        });
+
+        acc.process_chunk(ChatCompletionChunk {
+            id: "1".into(),
+            choices: vec![ChatChunkChoice {
+                index: 0,
+                delta: ChatDelta {
+                    role: None,
+                    content: Some(" world!".into()),
+                    tool_calls: None,
+                },
+                finish_reason: Some("stop".into()),
+            }],
+            model: "test".into(),
+            usage: None,
+        });
+
+        assert_eq!(acc.finish_reason(), Some("stop"));
+        let msg = acc.into_message().unwrap();
+        if let Content::MultiPart(blocks) = &msg.content {
+            if let Block::Text { text, .. } = &blocks[0] {
+                assert_eq!(text.to_string(), "Hello world!");
+            } else {
+                panic!("expected text block");
+            }
+        } else {
+            panic!("expected multipart");
+        }
+    }
+
+    #[test]
+    fn stream_accumulator_tool_call() {
+        let mut acc = ChatStreamAccumulator::new();
+
+        // First chunk: tool call header
+        acc.process_chunk(ChatCompletionChunk {
+            id: "1".into(),
+            choices: vec![ChatChunkChoice {
+                index: 0,
+                delta: ChatDelta {
+                    role: Some(ChatRole::Assistant),
+                    content: None,
+                    tool_calls: Some(vec![ChatToolCallDelta {
+                        index: 0,
+                        id: Some("call_abc".into()),
+                        kind: Some("function".into()),
+                        function: Some(ChatFunctionCallDelta {
+                            name: Some("search".into()),
+                            arguments: Some(r#"{"qu"#.into()),
+                        }),
+                    }]),
+                },
+                finish_reason: None,
+            }],
+            model: "test".into(),
+            usage: None,
+        });
+
+        // Second chunk: arguments continuation
+        acc.process_chunk(ChatCompletionChunk {
+            id: "1".into(),
+            choices: vec![ChatChunkChoice {
+                index: 0,
+                delta: ChatDelta {
+                    role: None,
+                    content: None,
+                    tool_calls: Some(vec![ChatToolCallDelta {
+                        index: 0,
+                        id: None,
+                        kind: None,
+                        function: Some(ChatFunctionCallDelta {
+                            name: None,
+                            arguments: Some(r#"ery":"test"}"#.into()),
+                        }),
+                    }]),
+                },
+                finish_reason: Some("tool_calls".into()),
+            }],
+            model: "test".into(),
+            usage: None,
+        });
+
+        let msg = acc.into_message().unwrap();
+        let tool_use = msg.tool_use().unwrap();
+        assert_eq!(tool_use.name, "search");
+        assert_eq!(tool_use.input["query"], "test");
+    }
+
+    #[test]
+    fn empty_accumulator_returns_none() {
+        let acc = ChatStreamAccumulator::new();
+        assert!(acc.into_message().is_none());
+    }
+
+    #[test]
+    fn chat_completion_request_serializes() {
+        let req = ChatCompletionRequest {
+            model: "cogito:14b".to_string(),
+            messages: vec![ChatMessage {
+                role: ChatRole::User,
+                content: Some(ChatContent::Text("hi".to_string())),
+                tool_calls: None,
+                tool_call_id: None,
+                name: None,
+            }],
+            tools: None,
+            tool_choice: None,
+            temperature: Some(0.7),
+            max_tokens: Some(1024),
+            top_p: None,
+            stop: None,
+            stream: None,
+        };
+
+        let json = serde_json::to_value(&req).unwrap();
+        assert_eq!(json["model"], "cogito:14b");
+        assert_eq!(json["messages"][0]["role"], "user");
+        assert_eq!(json["messages"][0]["content"], "hi");
+        assert!(json["temperature"].as_f64().unwrap() > 0.69);
+        assert!(json.get("tools").is_none());
+    }
+}

--- a/misanthropic/src/prompt.rs
+++ b/misanthropic/src/prompt.rs
@@ -3,7 +3,11 @@
 //!
 //! [Anthropic Messages API]: <https://docs.anthropic.com/en/api/messages>
 
-use std::{borrow::Cow, num::{NonZeroU16, NonZeroU32}, vec};
+use std::{
+    borrow::Cow,
+    num::{NonZeroU16, NonZeroU32},
+    vec,
+};
 
 use crate::{
     model,
@@ -708,7 +712,6 @@ impl<'a> Prompt<'a> {
     /// [`Sonnet35`]: crate::Model::Sonnet35
     /// [`Opus30`]: crate::Model::Opus30
     /// [`Haiku30`]: crate::Model::Haiku30
-    #[cfg(feature = "prompt-caching")]
     pub fn cache(mut self) -> Self {
         // If there are messages, add a cache breakpoint to the last one.
         if let Some(last) = self.messages.last_mut() {
@@ -1360,7 +1363,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg(feature = "prompt-caching")]
     fn test_cache() {
         // Test with nothing to cache. This should be a no-op.
         let request = Prompt::default().cache();
@@ -1372,7 +1374,6 @@ mod tests {
             name: "ping".into(),
             description: "Ping a server.".into(),
             schema: json!({}),
-            #[cfg(feature = "prompt-caching")]
             cache_control: None,
         });
 
@@ -1516,7 +1517,6 @@ mod tests {
             name: "ping".into(),
             description: "Ping a server.".into(),
             schema: schema.clone(),
-            #[cfg(feature = "prompt-caching")]
             cache_control: None,
         };
 
@@ -1615,7 +1615,6 @@ mod tests {
                     },
                     "required": ["host"]
                 }),
-                #[cfg(feature = "prompt-caching")]
                 cache_control: None,
             }])
             .set_system("You are a very succinct assistant.")
@@ -1638,7 +1637,6 @@ mod tests {
                     input: json!({
                         "host": "example.com"
                     }),
-                    #[cfg(feature = "prompt-caching")]
                     cache_control: None,
                 }
                 .into(),
@@ -1646,7 +1644,6 @@ mod tests {
                     tool_use_id: "abc123".into(),
                     content: "Pinging example.com.".into(),
                     is_error: false,
-                    #[cfg(feature = "prompt-caching")]
                     cache_control: None,
                 }
                 .into(),

--- a/misanthropic/src/prompt/message.rs
+++ b/misanthropic/src/prompt/message.rs
@@ -220,7 +220,6 @@ impl<'a> IntoIterator for Message<'a> {
         match self.content {
             Content::SinglePart(text) => vec![Block::Text {
                 text,
-                #[cfg(feature = "prompt-caching")]
                 cache_control: None,
             }]
             .into_iter(),
@@ -481,7 +480,6 @@ impl<'a> IntoIterator for UserMessage<'a> {
         match self.inner.content {
             Content::SinglePart(text) => vec![Block::Text {
                 text,
-                #[cfg(feature = "prompt-caching")]
                 cache_control: None,
             }]
             .into_iter(),
@@ -612,13 +610,10 @@ impl<'a> Content<'a> {
     /// - If the content is [`MultiPart`].
     pub fn unwrap_single_part(self) -> Block<'a> {
         match self {
-            #[cfg(feature = "prompt-caching")]
             Self::SinglePart(text) => Block::Text {
                 text,
                 cache_control: None,
             },
-            #[cfg(not(feature = "prompt-caching"))]
-            Self::SinglePart(text) => Block::Text { text },
             Self::MultiPart(_) => {
                 panic!("Content is MultiPart, not SinglePart");
             }
@@ -660,7 +655,6 @@ impl<'a> Content<'a> {
     ///
     /// [`SinglePart`]: Content::SinglePart
     /// [`MultiPart`]: Content::MultiPart
-    #[cfg(feature = "prompt-caching")]
     pub fn cache(&mut self) {
         if self.is_single_part() {
             let mut old = Content::MultiPart(vec![]);
@@ -668,10 +662,10 @@ impl<'a> Content<'a> {
             self.push(old.unwrap_single_part());
         }
 
-        if let Content::MultiPart(parts) = self {
-            if let Some(block) = parts.last_mut() {
-                block.cache();
-            }
+        if let Content::MultiPart(parts) = self
+            && let Some(block) = parts.last_mut()
+        {
+            block.cache();
         }
     }
 
@@ -715,7 +709,10 @@ impl<'a> Content<'a> {
     /// this will return a [`ContentMismatch`] error.
     ///
     /// It is an error to try to merge a single json delta into a content block.
-    pub fn push_delta(&mut self, delta: Delta<'a>) -> Result<(), DeltaError<'_>> {
+    pub fn push_delta(
+        &mut self,
+        delta: Delta<'a>,
+    ) -> Result<(), DeltaError<'_>> {
         if let Delta::Json { .. } = &delta {
             // It isn't possible to merge a single json delta into a content
             // block because ToolUse::input is a serde_json::Value and not a
@@ -757,7 +754,6 @@ impl<'a> Content<'a> {
                     Content::SinglePart(text) => {
                         Box::new(std::iter::once(Block::Text {
                             text,
-                            #[cfg(feature = "prompt-caching")]
                             cache_control: None,
                         }))
                     }
@@ -810,7 +806,6 @@ impl<'a> IntoIterator for Content<'a> {
         match self {
             Content::SinglePart(text) => vec![Block::Text {
                 text,
-                #[cfg(feature = "prompt-caching")]
                 cache_control: None,
             }]
             .into_iter(),
@@ -929,7 +924,6 @@ where
 
         *self = Self::MultiPart(vec![Block::Text {
             text,
-            #[cfg(feature = "prompt-caching")]
             cache_control: None,
         }]);
         // This can never recurse infinitely because we just converted to
@@ -985,7 +979,6 @@ pub enum Block<'a> {
         /// The actual text content.
         text: crate::CowStr<'a>,
         /// Use prompt caching. See [`Block::cache`] for more information.
-        #[cfg(feature = "prompt-caching")]
         #[serde(skip_serializing_if = "Option::is_none")]
         cache_control: Option<CacheControl>,
     },
@@ -1031,7 +1024,6 @@ pub enum Block<'a> {
         /// An base64 encoded image.
         image: Image<'a>,
         /// Use prompt caching. See [`Block::cache`] for more information.
-        #[cfg(feature = "prompt-caching")]
         #[serde(skip_serializing_if = "Option::is_none")]
         cache_control: Option<CacheControl>,
     },
@@ -1077,7 +1069,6 @@ impl<'a> Block<'a> {
     pub const fn const_text(text: &'a str) -> Self {
         Self::Text {
             text: std::borrow::Cow::Borrowed(text),
-            #[cfg(feature = "prompt-caching")]
             cache_control: None,
         }
     }
@@ -1089,7 +1080,6 @@ impl<'a> Block<'a> {
     {
         Self::Text {
             text: text.into(),
-            #[cfg(feature = "prompt-caching")]
             cache_control: None,
         }
     }
@@ -1246,7 +1236,6 @@ impl<'a> Block<'a> {
     /// however some blocks are automatically cached and will return false.
     ///
     /// [`Prompt::cache`]: crate::Prompt::cache
-    #[cfg(feature = "prompt-caching")]
     pub fn cache(&mut self) -> bool {
         use crate::tool;
 
@@ -1270,7 +1259,6 @@ impl<'a> Block<'a> {
     }
 
     /// Returns true if the block has a `cache_control` breakpoint.
-    #[cfg(feature = "prompt-caching")]
     pub const fn is_cached(&self) -> bool {
         use crate::tool;
 
@@ -1304,14 +1292,12 @@ impl<'a> Block<'a> {
         match self {
             Self::Text {
                 text,
-                #[cfg(feature = "prompt-caching")]
                 cache_control,
             } => Block::Text {
                 #[cfg(not(feature = "langsan"))]
                 text: std::borrow::Cow::Owned(text.into_owned()),
                 #[cfg(feature = "langsan")]
                 text: text.into_static(),
-                #[cfg(feature = "prompt-caching")]
                 cache_control,
             },
             Self::Thought { thought, signature } => Block::Thought {
@@ -1323,11 +1309,9 @@ impl<'a> Block<'a> {
             },
             Self::Image {
                 image,
-                #[cfg(feature = "prompt-caching")]
                 cache_control,
             } => Block::Image {
                 image: image.into_static(),
-                #[cfg(feature = "prompt-caching")]
                 cache_control,
             },
             Self::ToolUse { call } => Block::ToolUse {
@@ -1440,7 +1424,6 @@ impl From<String> for Block<'_> {
     fn from(text: String) -> Self {
         Self::Text {
             text: text.into(),
-            #[cfg(feature = "prompt-caching")]
             cache_control: None,
         }
     }
@@ -1450,7 +1433,6 @@ impl<'a> From<crate::CowStr<'a>> for Block<'a> {
     fn from(text: crate::CowStr<'a>) -> Self {
         Self::Text {
             text,
-            #[cfg(feature = "prompt-caching")]
             cache_control: None,
         }
     }
@@ -1460,7 +1442,6 @@ impl<'a> From<Image<'a>> for Block<'a> {
     fn from(image: Image<'a>) -> Self {
         Self::Image {
             image,
-            #[cfg(feature = "prompt-caching")]
             cache_control: None,
         }
     }
@@ -1502,7 +1483,6 @@ impl From<image::DynamicImage> for Block<'_> {
 }
 
 /// Cache control for prompt caching.
-#[cfg(feature = "prompt-caching")]
 #[derive(Clone, Default, Debug, Serialize, Deserialize, Hash)]
 #[cfg_attr(any(feature = "partial-eq", test), derive(PartialEq))]
 #[serde(tag = "type")]
@@ -1804,7 +1784,6 @@ mod tests {
             id: "tool_123".into(),
             name: "tool".into(),
             input: serde_json::json!({}),
-            #[cfg(feature = "prompt-caching")]
             cache_control: None,
         }
         .into();
@@ -1836,7 +1815,6 @@ mod tests {
             id: "tool_123".into(),
             name: "tool".into(),
             input: serde_json::json!({}),
-            #[cfg(feature = "prompt-caching")]
             cache_control: None,
         }
         .into();
@@ -1879,7 +1857,6 @@ mod tests {
                 id: "tool_123".into(),
                 name: "tool".into(),
                 input: serde_json::json!({}),
-                #[cfg(feature = "prompt-caching")]
                 cache_control: None,
             },
         };
@@ -1917,7 +1894,6 @@ mod tests {
         }];
         let mut block = Block::Text {
             text: "Hello, world!".into(),
-            #[cfg(feature = "prompt-caching")]
             cache_control: None,
         };
 
@@ -2034,7 +2010,6 @@ mod tests {
                 id: "tool_123".into(),
                 name: "tool".into(),
                 input: serde_json::json!({}),
-                #[cfg(feature = "prompt-caching")]
                 cache_control: None,
             },
         };
@@ -2091,7 +2066,6 @@ mod tests {
             tool_use_id: "tool_123".into(),
             content: Content::SinglePart("Hello, world!".into()),
             is_error: false,
-            #[cfg(feature = "prompt-caching")]
             cache_control: None,
         }
         .into();
@@ -2106,7 +2080,6 @@ mod tests {
             tool_use_id: "tool_123".into(),
             content: Content::SinglePart("Hello, world!".into()),
             is_error: true,
-            #[cfg(feature = "prompt-caching")]
             cache_control: None,
         }
         .into();
@@ -2123,7 +2096,6 @@ mod tests {
             id: "tool_123".into(),
             name: "tool".into(),
             input: serde_json::json!({}),
-            #[cfg(feature = "prompt-caching")]
             cache_control: None,
         };
 

--- a/misanthropic/src/response.rs
+++ b/misanthropic/src/response.rs
@@ -138,9 +138,7 @@ mod tests {
                 stop_sequence: None,
                 usage: Usage {
                     input_tokens: 1,
-                    #[cfg(feature = "prompt-caching")]
                     cache_creation_input_tokens: Some(2),
-                    #[cfg(feature = "prompt-caching")]
                     cache_read_input_tokens: Some(3),
                     output_tokens: 4,
                 },
@@ -336,18 +334,14 @@ mod tests {
     fn test_usage_add() {
         let mut a = Usage {
             input_tokens: 1,
-            #[cfg(feature = "prompt-caching")]
             cache_creation_input_tokens: Some(2),
-            #[cfg(feature = "prompt-caching")]
             cache_read_input_tokens: Some(3),
             output_tokens: 4,
         };
 
         let b = Usage {
             input_tokens: 5,
-            #[cfg(feature = "prompt-caching")]
             cache_creation_input_tokens: Some(6),
-            #[cfg(feature = "prompt-caching")]
             cache_read_input_tokens: Some(7),
             output_tokens: 8,
         };
@@ -355,9 +349,7 @@ mod tests {
         a += b;
 
         assert_eq!(a.input_tokens, 6);
-        #[cfg(feature = "prompt-caching")]
         assert_eq!(a.cache_creation_input_tokens, Some(8));
-        #[cfg(feature = "prompt-caching")]
         assert_eq!(a.cache_read_input_tokens, Some(10));
         assert_eq!(a.output_tokens, 12);
     }

--- a/misanthropic/src/response/message.rs
+++ b/misanthropic/src/response/message.rs
@@ -105,10 +105,8 @@ pub struct Usage {
     /// Number of input tokens used.
     pub input_tokens: u64,
     /// Number of input tokens used to create the cache entry.
-    #[cfg(feature = "prompt-caching")]
     pub cache_creation_input_tokens: Option<u64>,
     /// Number of input tokens read from the cache.
-    #[cfg(feature = "prompt-caching")]
     pub cache_read_input_tokens: Option<u64>,
     /// Number of output tokens generated.
     pub output_tokens: u64,
@@ -120,16 +118,14 @@ impl std::ops::Add<Usage> for Usage {
     fn add(self, rhs: Self) -> Self::Output {
         Self {
             input_tokens: self.input_tokens + rhs.input_tokens,
-            #[cfg(feature = "prompt-caching")]
             cache_creation_input_tokens: self
                 .cache_creation_input_tokens
                 .map(|c| c + rhs.cache_creation_input_tokens.unwrap_or(0))
-                .or_else(|| rhs.cache_creation_input_tokens),
-            #[cfg(feature = "prompt-caching")]
+                .or(rhs.cache_creation_input_tokens),
             cache_read_input_tokens: self
                 .cache_read_input_tokens
                 .map(|c| c + rhs.cache_read_input_tokens.unwrap_or(0))
-                .or_else(|| rhs.cache_read_input_tokens),
+                .or(rhs.cache_read_input_tokens),
             output_tokens: self.output_tokens + rhs.output_tokens,
         }
     }
@@ -213,7 +209,6 @@ mod tests {
             id: "id".into(),
             name: "name".into(),
             input: serde_json::json!({}),
-            #[cfg(feature = "prompt-caching")]
             cache_control: None,
         });
         assert!(message.tool_use().is_some());
@@ -260,9 +255,7 @@ mod tests {
             stop_sequence: None,
             usage: Usage {
                 input_tokens: 1,
-                #[cfg(feature = "prompt-caching")]
                 cache_creation_input_tokens: Some(2),
-                #[cfg(feature = "prompt-caching")]
                 cache_read_input_tokens: Some(3),
                 output_tokens: 4,
             },

--- a/misanthropic/src/stream.rs
+++ b/misanthropic/src/stream.rs
@@ -947,7 +947,6 @@ pub(crate) mod tests {
                 content_block,
             } => {
                 assert_eq!(index, 0);
-                #[cfg(feature = "prompt-caching")]
                 if let Block::Text {
                     text,
                     cache_control,
@@ -955,12 +954,6 @@ pub(crate) mod tests {
                 {
                     assert_eq!(text.as_ref(), "");
                     assert!(cache_control.is_none());
-                } else {
-                    panic!("Unexpected content block: {:?}", content_block);
-                }
-                #[cfg(not(feature = "prompt-caching"))]
-                if let Block::Text { text } = content_block {
-                    assert_eq!(text.as_ref(), "");
                 } else {
                     panic!("Unexpected content block: {:?}", content_block);
                 }
@@ -1155,7 +1148,6 @@ pub(crate) mod tests {
                     },
                     Block::Text {
                         text: "27 * 453 = 12,231".to_string().into(),
-                        #[cfg(feature = "prompt-caching")]
                         cache_control: None
                     }
                 ])
@@ -1198,7 +1190,6 @@ pub(crate) mod tests {
                     },
                     Block::Text {
                         text: "27 * 453 = 12,231".to_string().into(),
-                        #[cfg(feature = "prompt-caching")]
                         cache_control: None
                     }
                 ])

--- a/misanthropic/src/tool.rs
+++ b/misanthropic/src/tool.rs
@@ -147,7 +147,6 @@ pub struct Method<'a> {
     /// Set a cache breakpoint. See [`Prompt::cache`] for more information.
     ///
     /// [`Prompt::cache`] crate::Prompt::cache
-    #[cfg(feature = "prompt-caching")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub cache_control: Option<crate::prompt::message::CacheControl>,
 }
@@ -182,7 +181,6 @@ impl<'de> Deserialize<'de> for MethodBuilder<'_> {
             name: Cow<'static, str>,
             description: Cow<'static, str>,
             input_schema: serde_json::Value,
-            #[cfg(feature = "prompt-caching")]
             cache_control: Option<crate::prompt::message::CacheControl>,
         }
 
@@ -192,7 +190,6 @@ impl<'de> Deserialize<'de> for MethodBuilder<'_> {
             name,
             description,
             input_schema,
-            #[cfg(feature = "prompt-caching")]
             cache_control,
         } = foreign;
 
@@ -201,7 +198,6 @@ impl<'de> Deserialize<'de> for MethodBuilder<'_> {
                 name,
                 description,
                 schema: input_schema,
-                #[cfg(feature = "prompt-caching")]
                 cache_control,
             },
         })
@@ -221,7 +217,6 @@ impl<'a> MethodBuilder<'a> {
     /// [`cache_control`]: Spec::cache_control
     /// [`Ephemeral`]: crate::prompt::message::CacheControl::Ephemeral
     /// [`Prompt::cache`]: crate::prompt::Prompt::cache
-    #[cfg(feature = "prompt-caching")]
     pub fn cache(mut self) -> Self {
         self.tool.cache_control =
             Some(crate::prompt::message::CacheControl::Ephemeral);
@@ -444,7 +439,6 @@ impl<'a> MethodBuilder<'a> {
             name: Cow::Owned(self.tool.name.into_owned()),
             description: Cow::Owned(self.tool.description.into_owned()),
             schema: self.tool.schema,
-            #[cfg(feature = "prompt-caching")]
             cache_control: self.tool.cache_control,
         }
     }
@@ -475,7 +469,6 @@ impl<'a> Method<'a> {
                 name: name.into(),
                 description: Cow::Owned(String::new()),
                 schema: serde_json::Value::Null,
-                #[cfg(feature = "prompt-caching")]
                 cache_control: None,
             },
         }
@@ -495,7 +488,6 @@ impl<'a> Method<'a> {
                 "properties": {},
                 "required": []
             }),
-            #[cfg(feature = "prompt-caching")]
             cache_control: None,
         }
     }
@@ -523,7 +515,6 @@ impl<'a> Method<'a> {
                 },
                 "required": required_array
             }),
-            #[cfg(feature = "prompt-caching")]
             cache_control: None,
         }
     }
@@ -534,7 +525,6 @@ impl<'a> Method<'a> {
     /// [`cache_control`]: Self::cache_control
     /// [`Ephemeral`]: crate::prompt::message::CacheControl::Ephemeral
     /// [`Prompt::cache`]: crate::prompt::Prompt::cache
-    #[cfg(feature = "prompt-caching")]
     pub fn cache(&mut self) -> &mut Self {
         self.cache_control =
             Some(crate::prompt::message::CacheControl::Ephemeral);
@@ -543,7 +533,6 @@ impl<'a> Method<'a> {
 
     /// Returns true if the [`Method`] has a cache breakpoint set (if
     /// `cache_control` is [`Some`]).
-    #[cfg(feature = "prompt-caching")]
     pub fn is_cached(&self) -> bool {
         self.cache_control.is_some()
     }
@@ -569,7 +558,6 @@ impl<'a> Method<'a> {
             name: Cow::Owned(self.name.into_owned()),
             description: Cow::Owned(self.description.into_owned()),
             schema: self.schema,
-            #[cfg(feature = "prompt-caching")]
             cache_control: self.cache_control,
         }
     }
@@ -615,7 +603,6 @@ pub struct Use<'a> {
     /// Use prompt caching. See [`Prompt::cache`] for more information.
     ///
     /// [`Prompt::cache`]: crate::prompt::Prompt::cache
-    #[cfg(feature = "prompt-caching")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub cache_control: Option<crate::prompt::message::CacheControl>,
 }
@@ -628,7 +615,6 @@ impl Use<'_> {
             id: Cow::Owned(self.id.into_owned()),
             name: Cow::Owned(self.name.into_owned()),
             input: self.input,
-            #[cfg(feature = "prompt-caching")]
             cache_control: self.cache_control,
         }
     }
@@ -704,7 +690,6 @@ pub struct Result<'a> {
     /// Use prompt caching. See [`Prompt::cache`] for more information.
     ///
     /// crate::prompt::Prompt::cache
-    #[cfg(feature = "prompt-caching")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub cache_control: Option<crate::prompt::message::CacheControl>,
 }
@@ -717,7 +702,6 @@ impl Result<'_> {
             tool_use_id: Cow::Owned(self.tool_use_id.into_owned()),
             content: self.content.into_static(),
             is_error: self.is_error,
-            #[cfg(feature = "prompt-caching")]
             cache_control: self.cache_control,
         }
     }
@@ -899,7 +883,6 @@ mod tests {
             input: serde_json::json!({
                 "test_key": "test_value"
             }),
-            #[cfg(feature = "prompt-caching")]
             cache_control: None,
         };
 
@@ -1206,7 +1189,6 @@ mod tests {
             tool_use_id: "test_id".into(),
             content: "test_content".into(),
             is_error: false,
-            #[cfg(feature = "prompt-caching")]
             cache_control: None,
         };
 
@@ -1221,7 +1203,6 @@ mod tests {
             tool_use_id: "test_id".into(),
             content: "test_content".into(),
             is_error: false,
-            #[cfg(feature = "prompt-caching")]
             cache_control: None,
         };
 

--- a/misanthropic/src/tool/memory_palace/tool.rs
+++ b/misanthropic/src/tool/memory_palace/tool.rs
@@ -245,7 +245,6 @@ impl Tool for MemoryPalace {
                             tool_use_id: call.id,
                             content: "Input must be an object".into(),
                             is_error: true,
-                            #[cfg(feature = "prompt-caching")]
                             cache_control: None,
                         };
                     }
@@ -258,7 +257,6 @@ impl Tool for MemoryPalace {
                             tool_use_id: call.id,
                             content: "Missing required 'room' parameter".into(),
                             is_error: true,
-                            #[cfg(feature = "prompt-caching")]
                             cache_control: None,
                         };
                     }
@@ -271,7 +269,6 @@ impl Tool for MemoryPalace {
                             tool_use_id: call.id,
                             content: "Missing required 'content' parameter".into(),
                             is_error: true,
-                            #[cfg(feature = "prompt-caching")]
                             cache_control: None,
                         };
                     }
@@ -290,14 +287,12 @@ impl Tool for MemoryPalace {
                         tool_use_id: call.id,
                         content: format!("Memory stored with ID: {} in room '{}'", memory_id, room).into(),
                         is_error: false,
-                        #[cfg(feature = "prompt-caching")]
                         cache_control: None,
                     },
                     Err(err) => tool::Result {
                         tool_use_id: call.id,
                         content: format!("Failed to store memory: {}", err).into(),
                         is_error: true,
-                        #[cfg(feature = "prompt-caching")]
                         cache_control: None,
                     },
                 }
@@ -310,7 +305,6 @@ impl Tool for MemoryPalace {
                             tool_use_id: call.id,
                             content: "Input must be an object".into(),
                             is_error: true,
-                            #[cfg(feature = "prompt-caching")]
                             cache_control: None,
                         };
                     }
@@ -323,7 +317,6 @@ impl Tool for MemoryPalace {
                             tool_use_id: call.id,
                             content: "Missing required 'query' parameter".into(),
                             is_error: true,
-                            #[cfg(feature = "prompt-caching")]
                             cache_control: None,
                         };
                     }
@@ -336,7 +329,6 @@ impl Tool for MemoryPalace {
                                 tool_use_id: call.id,
                                 content: format!("No memories found for query: '{}'", query).into(),
                                 is_error: false,
-                                #[cfg(feature = "prompt-caching")]
                                 cache_control: None,
                             }
                         } else {
@@ -356,7 +348,6 @@ impl Tool for MemoryPalace {
                                 tool_use_id: call.id,
                                 content: response.into(),
                                 is_error: false,
-                                #[cfg(feature = "prompt-caching")]
                                 cache_control: None,
                             }
                         }
@@ -365,7 +356,6 @@ impl Tool for MemoryPalace {
                         tool_use_id: call.id,
                         content: format!("Failed to search memories: {}", err).into(),
                         is_error: true,
-                        #[cfg(feature = "prompt-caching")]
                         cache_control: None,
                     },
                 }
@@ -376,14 +366,12 @@ impl Tool for MemoryPalace {
                         tool_use_id: call.id,
                         content: summary.into(),
                         is_error: false,
-                        #[cfg(feature = "prompt-caching")]
                         cache_control: None,
                     },
                     Err(err) => tool::Result {
                         tool_use_id: call.id,
                         content: format!("Failed to get summary: {}", err).into(),
                         is_error: true,
-                        #[cfg(feature = "prompt-caching")]
                         cache_control: None,
                     },
                 }
@@ -396,7 +384,6 @@ impl Tool for MemoryPalace {
                             tool_use_id: call.id,
                             content: "Input must be an object".into(),
                             is_error: true,
-                            #[cfg(feature = "prompt-caching")]
                             cache_control: None,
                         };
                     }
@@ -409,7 +396,6 @@ impl Tool for MemoryPalace {
                             tool_use_id: call.id,
                             content: "Missing required 'room1' parameter".into(),
                             is_error: true,
-                            #[cfg(feature = "prompt-caching")]
                             cache_control: None,
                         };
                     }
@@ -422,7 +408,6 @@ impl Tool for MemoryPalace {
                             tool_use_id: call.id,
                             content: "Missing required 'room2' parameter".into(),
                             is_error: true,
-                            #[cfg(feature = "prompt-caching")]
                             cache_control: None,
                         };
                     }
@@ -433,14 +418,12 @@ impl Tool for MemoryPalace {
                         tool_use_id: call.id,
                         content: format!("Rooms '{}' and '{}' connected.", room1, room2).into(),
                         is_error: false,
-                        #[cfg(feature = "prompt-caching")]
                         cache_control: None,
                     },
                     Err(err) => tool::Result {
                         tool_use_id: call.id,
                         content: format!("Failed to connect rooms: {}", err).into(),
                         is_error: true,
-                        #[cfg(feature = "prompt-caching")]
                         cache_control: None,
                     },
                 }
@@ -463,7 +446,6 @@ impl Tool for MemoryPalace {
                             tool_use_id: call.id,
                             content: response.into(),
                             is_error: false,
-                            #[cfg(feature = "prompt-caching")]
                             cache_control: None,
                         }
                     }
@@ -471,7 +453,6 @@ impl Tool for MemoryPalace {
                         tool_use_id: call.id,
                         content: format!("Failed to list rooms: {}", err).into(),
                         is_error: true,
-                        #[cfg(feature = "prompt-caching")]
                         cache_control: None,
                     },
                 }
@@ -484,7 +465,6 @@ impl Tool for MemoryPalace {
                             tool_use_id: call.id,
                             content: "Input must be an object".into(),
                             is_error: true,
-                            #[cfg(feature = "prompt-caching")]
                             cache_control: None,
                         };
                     }
@@ -497,7 +477,6 @@ impl Tool for MemoryPalace {
                             tool_use_id: call.id,
                             content: "Missing required 'memory_id1' parameter".into(),
                             is_error: true,
-                            #[cfg(feature = "prompt-caching")]
                             cache_control: None,
                         };
                     }
@@ -510,7 +489,6 @@ impl Tool for MemoryPalace {
                             tool_use_id: call.id,
                             content: "Missing required 'memory_id2' parameter".into(),
                             is_error: true,
-                            #[cfg(feature = "prompt-caching")]
                             cache_control: None,
                         };
                     }
@@ -523,7 +501,6 @@ impl Tool for MemoryPalace {
                             tool_use_id: call.id,
                             content: "Missing required 'relationship_type' parameter".into(),
                             is_error: true,
-                            #[cfg(feature = "prompt-caching")]
                             cache_control: None,
                         };
                     }
@@ -539,14 +516,12 @@ impl Tool for MemoryPalace {
                         tool_use_id: call.id,
                         content: msg.into(),
                         is_error: false,
-                        #[cfg(feature = "prompt-caching")]
                         cache_control: None,
                     },
                     Err(err) => tool::Result {
                         tool_use_id: call.id,
                         content: format!("Failed to relate memories: {}", err).into(),
                         is_error: true,
-                        #[cfg(feature = "prompt-caching")]
                         cache_control: None,
                     },
                 }
@@ -559,7 +534,6 @@ impl Tool for MemoryPalace {
                             tool_use_id: call.id,
                             content: "Input must be an object".into(),
                             is_error: true,
-                            #[cfg(feature = "prompt-caching")]
                             cache_control: None,
                         };
                     }
@@ -572,7 +546,6 @@ impl Tool for MemoryPalace {
                             tool_use_id: call.id,
                             content: "Missing required 'memory_id' parameter".into(),
                             is_error: true,
-                            #[cfg(feature = "prompt-caching")]
                             cache_control: None,
                         };
                     }
@@ -596,7 +569,6 @@ impl Tool for MemoryPalace {
                                 tool_use_id: call.id,
                                 content: format!("No related memories found for ID '{}'", memory_id).into(),
                                 is_error: false,
-                                #[cfg(feature = "prompt-caching")]
                                 cache_control: None,
                             }
                         } else {
@@ -616,7 +588,6 @@ impl Tool for MemoryPalace {
                                 tool_use_id: call.id,
                                 content: response.into(),
                                 is_error: false,
-                                #[cfg(feature = "prompt-caching")]
                                 cache_control: None,
                             }
                         }
@@ -625,7 +596,6 @@ impl Tool for MemoryPalace {
                         tool_use_id: call.id,
                         content: format!("Failed to find related memories: {}", err).into(),
                         is_error: true,
-                        #[cfg(feature = "prompt-caching")]
                         cache_control: None,
                     },
                 }
@@ -638,7 +608,6 @@ impl Tool for MemoryPalace {
                             tool_use_id: call.id,
                             content: "Input must be an object".into(),
                             is_error: true,
-                            #[cfg(feature = "prompt-caching")]
                             cache_control: None,
                         };
                     }
@@ -651,7 +620,6 @@ impl Tool for MemoryPalace {
                             tool_use_id: call.id,
                             content: "Missing required 'memory_id' parameter".into(),
                             is_error: true,
-                            #[cfg(feature = "prompt-caching")]
                             cache_control: None,
                         };
                     }
@@ -670,14 +638,12 @@ impl Tool for MemoryPalace {
                         tool_use_id: call.id,
                         content: msg.into(),
                         is_error: false,
-                        #[cfg(feature = "prompt-caching")]
                         cache_control: None,
                     },
                     Err(err) => tool::Result {
                         tool_use_id: call.id,
                         content: format!("Failed to extract concepts: {}", err).into(),
                         is_error: true,
-                        #[cfg(feature = "prompt-caching")]
                         cache_control: None,
                     },
                 }
@@ -690,7 +656,6 @@ impl Tool for MemoryPalace {
                             tool_use_id: call.id,
                             content: "Input must be an object".into(),
                             is_error: true,
-                            #[cfg(feature = "prompt-caching")]
                             cache_control: None,
                         };
                     }
@@ -703,7 +668,6 @@ impl Tool for MemoryPalace {
                             tool_use_id: call.id,
                             content: "Missing required 'concept_name' parameter".into(),
                             is_error: true,
-                            #[cfg(feature = "prompt-caching")]
                             cache_control: None,
                         };
                     }
@@ -716,7 +680,6 @@ impl Tool for MemoryPalace {
                                 tool_use_id: call.id,
                                 content: format!("No memories found for concept: '{}'", concept_name).into(),
                                 is_error: false,
-                                #[cfg(feature = "prompt-caching")]
                                 cache_control: None,
                             }
                         } else {
@@ -736,7 +699,6 @@ impl Tool for MemoryPalace {
                                 tool_use_id: call.id,
                                 content: response.into(),
                                 is_error: false,
-                                #[cfg(feature = "prompt-caching")]
                                 cache_control: None,
                             }
                         }
@@ -745,7 +707,6 @@ impl Tool for MemoryPalace {
                         tool_use_id: call.id,
                         content: format!("Failed to find memories by concept: {}", err).into(),
                         is_error: true,
-                        #[cfg(feature = "prompt-caching")]
                         cache_control: None,
                     },
                 }
@@ -756,14 +717,12 @@ impl Tool for MemoryPalace {
                         tool_use_id: call.id,
                         content: stats.into(),
                         is_error: false,
-                        #[cfg(feature = "prompt-caching")]
                         cache_control: None,
                     },
                     Err(err) => tool::Result {
                         tool_use_id: call.id,
                         content: format!("Failed to get graph stats: {}", err).into(),
                         is_error: true,
-                        #[cfg(feature = "prompt-caching")]
                         cache_control: None,
                     },
                 }
@@ -776,7 +735,6 @@ impl Tool for MemoryPalace {
                             tool_use_id: call.id,
                             content: "Input must be an object".into(),
                             is_error: true,
-                            #[cfg(feature = "prompt-caching")]
                             cache_control: None,
                         };
                     }
@@ -789,7 +747,6 @@ impl Tool for MemoryPalace {
                             tool_use_id: call.id,
                             content: "Missing required 'memory_id' parameter".into(),
                             is_error: true,
-                            #[cfg(feature = "prompt-caching")]
                             cache_control: None,
                         };
                     }
@@ -818,7 +775,6 @@ impl Tool for MemoryPalace {
                                 tool_use_id: call.id,
                                 content: format!("No memories found within distance {} from ID '{}'", max_distance, memory_id).into(),
                                 is_error: false,
-                                #[cfg(feature = "prompt-caching")]
                                 cache_control: None,
                             }
                         } else {
@@ -839,7 +795,6 @@ impl Tool for MemoryPalace {
                                 tool_use_id: call.id,
                                 content: response.into(),
                                 is_error: false,
-                                #[cfg(feature = "prompt-caching")]
                                 cache_control: None,
                             }
                         }
@@ -848,7 +803,6 @@ impl Tool for MemoryPalace {
                         tool_use_id: call.id,
                         content: format!("Failed to find memories via BFS: {}", err).into(),
                         is_error: true,
-                        #[cfg(feature = "prompt-caching")]
                         cache_control: None,
                     },
                 }
@@ -861,7 +815,6 @@ impl Tool for MemoryPalace {
                 )
                 .into(),
                 is_error: true,
-                #[cfg(feature = "prompt-caching")]
                 cache_control: None,
             },
         }

--- a/misanthropic/src/tool/memory_palace_tests.rs
+++ b/misanthropic/src/tool/memory_palace_tests.rs
@@ -314,7 +314,6 @@ mod tests {
                 "content": "test content",
                 "tags": ["test_tag"]
             }),
-            #[cfg(feature = "prompt-caching")]
             cache_control: None,
         };
 
@@ -344,7 +343,6 @@ mod tests {
             input: json!({
                 "query": "AI"
             }),
-            #[cfg(feature = "prompt-caching")]
             cache_control: None,
         };
 
@@ -361,7 +359,6 @@ mod tests {
             id: "test_id".into(),
             name: "MemoryPalace::invalid_method".into(),
             input: json!({}),
-            #[cfg(feature = "prompt-caching")]
             cache_control: None,
         };
 
@@ -384,7 +381,6 @@ mod tests {
                 "room": "test_room"
                 // missing content and tags
             }),
-            #[cfg(feature = "prompt-caching")]
             cache_control: None,
         };
 
@@ -546,7 +542,6 @@ mod tests {
                 "decay_factor": 0.8,
                 "min_score": 0.1
             }),
-            #[cfg(feature = "prompt-caching")]
             cache_control: None,
         };
 
@@ -818,7 +813,6 @@ mod tests {
                 "max_depth": 2,
                 "min_strength": 0.1
             }),
-            #[cfg(feature = "prompt-caching")]
             cache_control: None,
         };
 
@@ -836,7 +830,6 @@ mod tests {
                 "min_strength": 0.1
                 // missing memory_id
             }),
-            #[cfg(feature = "prompt-caching")]
             cache_control: None,
         };
 
@@ -853,7 +846,6 @@ mod tests {
                 "max_depth": 2,
                 "min_strength": 0.1
             }),
-            #[cfg(feature = "prompt-caching")]
             cache_control: None,
         };
 
@@ -870,7 +862,6 @@ mod tests {
                 "max_depth": 2,
                 "min_strength": 0.1
             }),
-            #[cfg(feature = "prompt-caching")]
             cache_control: None,
         };
 

--- a/misanthropic/src/tool/notepad.rs
+++ b/misanthropic/src/tool/notepad.rs
@@ -68,7 +68,6 @@ impl<'a> Tool for Notepad<'a> {
                     "`Notepad::push` is the only method available on `Notepad`"
                         .into(),
                 is_error: true,
-                #[cfg(feature = "prompt-caching")]
                 cache_control: None,
             };
         }
@@ -86,7 +85,6 @@ impl<'a> Tool for Notepad<'a> {
                     detail
                 ).into(),
                 is_error: true,
-                #[cfg(feature = "prompt-caching")]
                 cache_control: None,
             };
         };
@@ -101,7 +99,6 @@ impl<'a> Tool for Notepad<'a> {
                     tool_use_id: call.id,
                     content: "You cannot put `<notepad>` or `</notepad>` in your note.".into(),
                     is_error: true,
-                    #[cfg(feature = "prompt-caching")]
                     cache_control: None,
                 };
             }
@@ -113,7 +110,6 @@ impl<'a> Tool for Notepad<'a> {
                     tool_use_id: call.id,
                     content: "You cannot put `<note>` or `</note>` in your note. `notepad` will handle it.".into(),
                     is_error: true,
-                    #[cfg(feature = "prompt-caching")]
                     cache_control: None,
                 };
             }
@@ -128,7 +124,6 @@ impl<'a> Tool for Notepad<'a> {
                 tool_use_id: call.id,
                 content: "`note` must be a string.".into(),
                 is_error: true,
-                #[cfg(feature = "prompt-caching")]
                 cache_control: None,
             };
         }
@@ -137,7 +132,6 @@ impl<'a> Tool for Notepad<'a> {
             tool_use_id: call.id,
             content: "Note taken.".into(),
             is_error: false,
-            #[cfg(feature = "prompt-caching")]
             cache_control: None,
         }
     }
@@ -322,7 +316,6 @@ mod tests {
             input: json!({
                 "note": "Hello, world!"
             }),
-            #[cfg(feature = "prompt-caching")]
             cache_control: None,
         };
         let result = notepad.call(call).await;
@@ -355,7 +348,6 @@ mod tests {
             input: json!({
                 "note": "Hello, world!"
             }),
-            #[cfg(feature = "prompt-caching")]
             cache_control: None,
         };
         let result = toolbox.call(call).await;

--- a/misanthropic/src/tool/toolbox.rs
+++ b/misanthropic/src/tool/toolbox.rs
@@ -277,7 +277,6 @@ impl Tool for ToolBox {
                     )
                         .into(),
                     is_error: true,
-                    #[cfg(feature = "prompt-caching")]
                     cache_control: None,
                 };
             }
@@ -295,7 +294,6 @@ impl Tool for ToolBox {
                 )
                     .into(),
                 is_error: true,
-                #[cfg(feature = "prompt-caching")]
                 cache_control: None,
             }
         }
@@ -423,7 +421,6 @@ mod tests {
                         },
                     },
                 }),
-                #[cfg(feature = "prompt-caching")]
                 cache_control: None,
             }))
         }
@@ -435,7 +432,6 @@ mod tests {
                 tool_use_id: id,
                 content: "Tool called".into(),
                 is_error: false,
-                #[cfg(feature = "prompt-caching")]
                 cache_control: None,
             }
         }
@@ -548,7 +544,6 @@ mod tests {
             id: "id".into(),
             name: "toolbox::TestTool::test".into(),
             input: serde_json::json!({}),
-            #[cfg(feature = "prompt-caching")]
             cache_control: None,
         };
         let result = toolbox.call(call.clone()).await;


### PR DESCRIPTION
## Summary

- **Remove `prompt-caching` feature gate**: Prompt caching is out of beta. All `cache_control` fields are now unconditional. The `beta` and `prompt-caching` features are removed.
- **Add `openai` feature**: New `src/openai.rs` module with OpenAI Chat Completions-compatible types and bidirectional conversion from misanthropic primitives. Enables using `Prompt`/`Message`/`tool::Method` as canonical representation, then serializing to Ollama/vLLM/OpenAI endpoints.

### OpenAI module includes:
- `ChatCompletionRequest`/`ChatCompletionResponse` types
- Streaming: `ChatCompletionChunk`, `ChatDelta`, `ChatStreamAccumulator`
- `Prompt` → `ChatCompletionRequest` conversion
- `ChatCompletionResponse` → `Message` conversion
- `tool::Method` ↔ `ChatTool` conversion
- `tool::Use` ↔ `ChatToolCall` conversion
- `Block::Image` → `data:` URI for OpenAI image content
- `Block::Thought` stripped (no OpenAI equivalent)

## Test plan
- [x] 163 tests pass with `--features openai`
- [x] 151 tests pass with default features (no regression)
- [x] `cargo fmt` clean
- [ ] Manual test with Ollama endpoint (future: agora seed runner integration)

🤖 Generated with [Claude Code](https://claude.com/claude-code)