### PR TITLE
feat(cot): Add <think> tags to default tag list

### DIFF
--- a/misanthropic/src/cot.rs
+++ b/misanthropic/src/cot.rs
@@ -12,10 +12,10 @@ use crate::prompt::{
 
 /// Supported start tags for [`Thought`]s.
 pub const DEFAULT_START_TAGS: &[&str] =
-    &["<thinking>", "<inner-voice>", "<thought>"];
+    &["<thinking>", "<think>", "<inner-voice>", "<thought>"];
 /// Supported end tags for [`Thought`]s.
 pub const DEFAULT_END_TAGS: &[&str] =
-    &["</thinking>", "</inner-voice>", "</thought>"];
+    &["</thinking>", "</think>", "</inner-voice>", "</thought>"];
 
 /// Contents of a `<thinking>` element.
 #[derive(Debug, Clone, Deref, derive_more::Display)]


### PR DESCRIPTION
## Summary
- Add `<think>` / `</think>` to `DEFAULT_START_TAGS` / `DEFAULT_END_TAGS` in the `cot` module
- Ollama thinking models (e.g. cogito) use these tags for chain-of-thought, so the `Thinkable` trait now parses them out of the box without needing `thoughts_custom()`

## Test plan
- [x] `cargo test` — 152 pass
- [ ] Manual test with cogito via Ollama to verify `<think>` blocks are parsed into `Thought` variants

🤖 Generated with [Claude Code](https://claude.com/claude-code)