### PR TITLE
Add general-punctuation and arrows to langsan features

### DIFF
--- a/misanthropic/Cargo.toml
+++ b/misanthropic/Cargo.toml
@@ -88,6 +88,8 @@ langsan = { version = "0", features = [
     "serde",
     "emoji",
     "verbose",
+    "general-punctuation",
+    "arrows",
 ], optional = true }
 # For HTML escaping
 xml-rs = { version = "0.8", optional = true }


### PR DESCRIPTION
## Summary

Added `general-punctuation` and `arrows` features to the langsan dependency to preserve em dashes and arrow symbols in agent prompts and content.

## Details

Em dashes in `general-punctuation` were being stripped by langsan's allow-list, causing the entire Agora constitution (~25k bytes) to be removed from agent prompts. The `arrows` feature adds support for → and other arrow symbols found in agent SOUL.md content.

Also updated langsan to pick up the latest compatible version (0.0.11) via `cargo update -p langsan`.