### PR TITLE
feat: Add CachedPrompt wrapper to prevent cache prefix mutation

### DIFF
--- a/misanthropic/src/lib.rs
+++ b/misanthropic/src/lib.rs
@@ -30,7 +30,7 @@ pub mod model;
 pub use model::{AnthropicModel, Model};
 
 pub mod prompt;
-pub use prompt::Prompt;
+pub use prompt::{CachedPrompt, Prompt};
 
 pub mod stream;
 pub use stream::Stream;

--- a/misanthropic/src/prompt.rs
+++ b/misanthropic/src/prompt.rs
@@ -25,6 +25,9 @@ pub use message::{AssistantMessage, Message, UserMessage};
 pub mod thinking;
 pub use thinking::Thinking;
 
+pub mod cached;
+pub use cached::CachedPrompt;
+
 /// Request for the [Anthropic Messages API].
 ///
 /// [Anthropic Messages API]: <https://docs.anthropic.com/en/api/messages>

--- a/misanthropic/src/prompt/cached.rs
+++ b/misanthropic/src/prompt/cached.rs
@@ -1,0 +1,380 @@
+//! A [`Prompt`] wrapper that prevents mutation of the
+//! [cache prefix](https://docs.anthropic.com/en/docs/build-with-claude/prompt-caching).
+//!
+//! The Anthropic prompt cache is keyed on the prefix: `tools` → `system` →
+//! `messages`, in that order.  Mutating any field that participates in the
+//! prefix (tools, system, tool_choice, thinking, model) after a cache entry
+//! has been written silently invalidates the cache and turns every subsequent
+//! request into a full-price cache *write* instead of a cheap *read*.
+//!
+//! [`CachedPrompt`] makes this class of bug a compile error: the inner
+//! [`Prompt`] is private, and only operations that preserve the cache prefix
+//! are exposed.
+//!
+//! # Cache-safe operations
+//!
+//! | Method | Why it's safe |
+//! |---|---|
+//! | [`push_message`] | Appends after the prefix; cache reads via lookback |
+//! | [`cache`] | Adds a breakpoint — doesn't change content |
+//! | [`set_max_tokens`] | Not part of the cache key |
+//! | [`set_temperature`] | Not part of the cache key |
+//! | [`set_top_k`] | Not part of the cache key |
+//! | [`set_top_p`] | Not part of the cache key |
+//! | [`set_stop_sequences`] | Not part of the cache key |
+//! | [`set_metadata`] | Not part of the cache key |
+//!
+//! [`push_message`]: CachedPrompt::push_message
+//! [`cache`]: CachedPrompt::cache
+//! [`set_max_tokens`]: CachedPrompt::set_max_tokens
+//! [`set_temperature`]: CachedPrompt::set_temperature
+//! [`set_top_k`]: CachedPrompt::set_top_k
+//! [`set_top_p`]: CachedPrompt::set_top_p
+//! [`set_stop_sequences`]: CachedPrompt::set_stop_sequences
+//! [`set_metadata`]: CachedPrompt::set_metadata
+//!
+//! # Cache-breaking fields (immutable after construction)
+//!
+//! | Field | Invalidates |
+//! |---|---|
+//! | `tools` / `functions` | Everything |
+//! | `system` | System + messages cache |
+//! | `tool_choice` | Messages cache |
+//! | `thinking` | Messages cache |
+//! | `model` | Everything (different model = different cache) |
+//!
+//! # Breakpoint budget
+//!
+//! The API supports up to 4 explicit cache breakpoints.  If more are present,
+//! the API keeps the last 4.  This means you can freely call [`cache`] each
+//! turn without tracking how many breakpoints exist.
+//!
+//! [`cache`]: CachedPrompt::cache
+
+use std::{
+    borrow::Cow,
+    num::{NonZeroU16, NonZeroU32},
+    ops::Deref,
+};
+
+use serde::{Deserialize, Serialize};
+
+use super::{Message, Prompt, TurnOrderError};
+
+/// A [`Prompt`] with an immutable cache prefix.
+///
+/// Created via [`From<Prompt>`] (which adds a cache breakpoint) or
+/// [`CachedPrompt::uncached`] (which does not).
+///
+/// To deliberately break the cache (e.g. removing tools for a different
+/// phase), call [`into_inner`] — the explicit escape hatch.
+///
+/// [`into_inner`]: CachedPrompt::into_inner
+#[derive(Clone)]
+#[cfg_attr(any(feature = "partial-eq", test), derive(PartialEq))]
+pub struct CachedPrompt<'a> {
+    inner: Prompt<'a>,
+}
+
+impl std::fmt::Debug for CachedPrompt<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("CachedPrompt")
+            .field("inner", &self.inner)
+            .finish()
+    }
+}
+
+// --- Construction -----------------------------------------------------------
+
+impl<'a> From<Prompt<'a>> for CachedPrompt<'a> {
+    /// Freeze the prompt and add a cache breakpoint on the last cacheable
+    /// block.  This is the preferred constructor for most use cases.
+    fn from(prompt: Prompt<'a>) -> Self {
+        Self {
+            inner: prompt.cache(),
+        }
+    }
+}
+
+impl<'a> CachedPrompt<'a> {
+    /// Freeze the prompt *without* adding a cache breakpoint.
+    ///
+    /// Use this when the prompt already has explicit `cache_control` markers
+    /// set during construction (e.g. on individual system blocks or tools).
+    pub fn uncached(prompt: Prompt<'a>) -> Self {
+        Self { inner: prompt }
+    }
+}
+
+// --- Cache-safe mutations ---------------------------------------------------
+
+impl<'a> CachedPrompt<'a> {
+    /// Append a [`Message`] to the conversation.
+    ///
+    /// This is always cache-safe: new messages are appended after the prefix,
+    /// and the API's 20-block lookback finds earlier cache entries.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`TurnOrderError`] if the turn order would be violated
+    /// (consecutive messages from the same role).
+    pub fn push_message<M>(&mut self, message: M) -> Result<(), TurnOrderError>
+    where
+        M: Into<Message<'a>>,
+    {
+        self.inner.push_message(message)
+    }
+
+    /// Add a cache breakpoint on the last cacheable block.
+    ///
+    /// Call this after appending messages to extend the cached region.
+    /// The API keeps only the last 4 breakpoints, so calling this every
+    /// turn is safe.
+    pub fn cache(&mut self) {
+        // Prompt::cache() is `fn cache(mut self) -> Self`, so we need to
+        // temporarily take ownership.
+        let taken = std::mem::take(&mut self.inner);
+        self.inner = taken.cache();
+    }
+
+    /// Set `max_tokens`.  Not part of the cache key.
+    pub fn set_max_tokens(&mut self, max_tokens: NonZeroU32) {
+        self.inner.max_tokens = max_tokens;
+    }
+
+    /// Set `temperature`.  Not part of the cache key.
+    pub fn set_temperature(&mut self, temperature: Option<f32>) {
+        self.inner.temperature = temperature;
+    }
+
+    /// Set `top_k`.  Not part of the cache key.
+    pub fn set_top_k(&mut self, top_k: Option<NonZeroU16>) {
+        self.inner.top_k = top_k;
+    }
+
+    /// Set `top_p`.  Not part of the cache key.
+    pub fn set_top_p(&mut self, top_p: Option<f32>) {
+        self.inner.top_p = top_p;
+    }
+
+    /// Set `stop_sequences`.  Not part of the cache key.
+    pub fn set_stop_sequences(
+        &mut self,
+        stop_sequences: Option<Vec<Cow<'a, str>>>,
+    ) {
+        self.inner.stop_sequences = stop_sequences;
+    }
+
+    /// Set request `metadata`.  Not part of the cache key.
+    pub fn set_metadata(
+        &mut self,
+        metadata: serde_json::Map<String, serde_json::Value>,
+    ) {
+        self.inner.metadata = metadata;
+    }
+}
+
+// --- Conversions ------------------------------------------------------------
+
+impl<'a> CachedPrompt<'a> {
+    /// Consume the wrapper and return the inner [`Prompt`].
+    ///
+    /// **This is an explicit escape hatch.**  After calling this, the prompt
+    /// can be freely mutated — including cache-breaking fields.  Use this
+    /// when you deliberately need to change the prefix (e.g. removing tools
+    /// for a reflect phase).
+    pub fn into_inner(self) -> Prompt<'a> {
+        self.inner
+    }
+
+    /// Convert to `'static` lifetime, mirroring [`Prompt::into_static`].
+    pub fn into_static(self) -> CachedPrompt<'static> {
+        CachedPrompt {
+            inner: self.inner.into_static(),
+        }
+    }
+}
+
+// --- Read-only access -------------------------------------------------------
+
+/// `Deref` provides read-only access to all [`Prompt`] fields.
+///
+/// There is intentionally **no** `DerefMut` — preventing direct mutation of
+/// cache-prefix fields like `tool_choice` and `functions`.
+impl<'a> Deref for CachedPrompt<'a> {
+    type Target = Prompt<'a>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}
+
+impl<'a> AsRef<Prompt<'a>> for CachedPrompt<'a> {
+    fn as_ref(&self) -> &Prompt<'a> {
+        &self.inner
+    }
+}
+
+// --- Serialization ----------------------------------------------------------
+
+/// Serializes identically to the inner [`Prompt`], so this works with
+/// [`Client::message`](crate::Client::message) which takes `P: Serialize`.
+impl Serialize for CachedPrompt<'_> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        self.inner.serialize(serializer)
+    }
+}
+
+/// Deserializes as a [`Prompt`] and wraps it *without* adding a cache
+/// breakpoint (since the serialized form may already contain breakpoints).
+impl<'de, 'a: 'de> Deserialize<'de> for CachedPrompt<'a> {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        Prompt::deserialize(deserializer).map(Self::uncached)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::prompt::message::Role;
+
+    #[test]
+    fn from_prompt_adds_cache_breakpoint() {
+        let prompt = Prompt {
+            system: Some(crate::prompt::message::Content::text(
+                "You are a helpful assistant.",
+            )),
+            ..Default::default()
+        };
+
+        let cached = CachedPrompt::from(prompt);
+
+        // The system content should now have a cache_control marker.
+        // (cache() falls through: no messages → caches system)
+        match cached.system.as_ref().unwrap() {
+            crate::prompt::message::Content::MultiPart(blocks) => {
+                let last = blocks.last().unwrap();
+                assert!(
+                    last.is_cached(),
+                    "expected cache_control on system block"
+                );
+            }
+            crate::prompt::message::Content::SinglePart(_) => {
+                panic!("expected MultiPart after cache()")
+            }
+        }
+    }
+
+    #[test]
+    fn uncached_does_not_add_breakpoint() {
+        let prompt = Prompt {
+            system: Some(crate::prompt::message::Content::text(
+                "You are a helpful assistant.",
+            )),
+            ..Default::default()
+        };
+
+        let cached = CachedPrompt::uncached(prompt);
+
+        // System should still be SinglePart — no cache() was called.
+        assert!(
+            cached.system.as_ref().unwrap().is_single_part(),
+            "expected SinglePart (no cache breakpoint)"
+        );
+    }
+
+    #[test]
+    fn push_message_works() {
+        let prompt = Prompt::default();
+        let mut cached = CachedPrompt::from(prompt);
+
+        cached
+            .push_message((Role::User, "Hello"))
+            .expect("first message should succeed");
+        cached
+            .push_message((Role::Assistant, "Hi there"))
+            .expect("assistant response should succeed");
+
+        assert_eq!(cached.messages.len(), 2);
+    }
+
+    #[test]
+    fn push_message_enforces_turn_order() {
+        let prompt = Prompt::default();
+        let mut cached = CachedPrompt::from(prompt);
+
+        cached
+            .push_message((Role::User, "Hello"))
+            .expect("first message should succeed");
+        let result = cached.push_message((Role::User, "Hello again"));
+        assert!(result.is_err(), "consecutive user messages should fail");
+    }
+
+    #[test]
+    fn set_max_tokens_works() {
+        let prompt = Prompt::default();
+        let mut cached = CachedPrompt::from(prompt);
+
+        cached.set_max_tokens(NonZeroU32::new(512).unwrap());
+        assert_eq!(cached.max_tokens, NonZeroU32::new(512).unwrap());
+    }
+
+    #[test]
+    fn into_inner_returns_prompt() {
+        let prompt = Prompt {
+            system: Some(crate::prompt::message::Content::text("test")),
+            ..Default::default()
+        };
+
+        let cached = CachedPrompt::from(prompt);
+        let inner = cached.into_inner();
+
+        // We can now mutate freely — this is the escape hatch.
+        assert!(inner.system.is_some());
+    }
+
+    #[test]
+    fn serialization_roundtrip() {
+        let mut prompt = Prompt::default();
+        prompt
+            .push_message((Role::User, "test"))
+            .expect("first message");
+
+        let cached = CachedPrompt::from(prompt);
+        let json = serde_json::to_string(&cached).expect("serialize");
+        let deserialized: CachedPrompt<'_> =
+            serde_json::from_str(&json).expect("deserialize");
+
+        assert_eq!(cached.messages.len(), deserialized.messages.len());
+    }
+
+    #[test]
+    fn into_static_works() {
+        let prompt = Prompt {
+            system: Some(crate::prompt::message::Content::text("test")),
+            ..Default::default()
+        };
+        let cached = CachedPrompt::from(prompt);
+        let _static_cached: CachedPrompt<'static> = cached.into_static();
+    }
+
+    #[test]
+    fn deref_provides_read_access() {
+        let prompt = Prompt {
+            max_tokens: NonZeroU32::new(1024).unwrap(),
+            ..Default::default()
+        };
+        let cached = CachedPrompt::from(prompt);
+
+        // Can read via Deref
+        assert_eq!(cached.max_tokens, NonZeroU32::new(1024).unwrap());
+        assert!(cached.tool_choice.is_none());
+        assert!(cached.functions.is_none());
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `CachedPrompt<'a>` wrapper that makes Anthropic prompt cache prefix mutation a compile error
- Inner `Prompt` is private — only cache-safe operations exposed: `push_message()`, `cache()`, `set_max_tokens()`, `set_temperature()`, etc.
- Cache-prefix fields (`tools`/`functions`, `system`, `tool_choice`, `thinking`, `model`) are immutable after construction
- `From<Prompt>` adds a cache breakpoint; `uncached()` freezes without one
- `into_inner()` is the explicit escape hatch for deliberate prefix changes
- `Deref<Target=Prompt>` for read-only access (no `DerefMut`)
- `Serialize`/`Deserialize` for direct use with `Client::message()`

## Motivation

In the Agora seed runner, `scheduler.rs` lines 1023-1024 set `tool_choice = None` and `functions = None` on a prompt after construction, silently invalidating the Anthropic prompt cache. This turned every batch request into a full-price cache write instead of a 10x cheaper cache read. `CachedPrompt` makes this class of bug a compile error.

## Test plan

- [x] 9 unit tests covering construction, mutation safety, serialization roundtrip, turn order enforcement
- [x] Full `cargo test --lib` passes (167 tests, 0 failures)
- [ ] Wire into agora scheduler to verify compile-time catch of the prefix mutation bug

🤖 Generated with [Claude Code](https://claude.com/claude-code)