### PR TITLE
feat: Add FromIterator<Block> for UserMessage and AssistantMessage

### DIFF
--- a/misanthropic/src/prompt/message.rs
+++ b/misanthropic/src/prompt/message.rs
@@ -358,6 +358,15 @@ impl<'a> From<AssistantMessage<'a>> for Content<'a> {
     }
 }
 
+impl<'a, T> FromIterator<T> for AssistantMessage<'a>
+where
+    T: Into<Block<'a>>,
+{
+    fn from_iter<I: IntoIterator<Item = T>>(iter: I) -> Self {
+        Self::from(Content::from_iter(iter))
+    }
+}
+
 impl<'a> TryFrom<Message<'a>> for AssistantMessage<'a> {
     type Error = NotTheAssistant;
 
@@ -469,6 +478,15 @@ impl<'a> From<tool::Result<'a>> for UserMessage<'a> {
         UserMessage {
             inner: result.into(),
         }
+    }
+}
+
+impl<'a, T> FromIterator<T> for UserMessage<'a>
+where
+    T: Into<Block<'a>>,
+{
+    fn from_iter<I: IntoIterator<Item = T>>(iter: I) -> Self {
+        Self::from(Content::from_iter(iter))
     }
 }
 
@@ -2289,6 +2307,49 @@ mod tests {
         let ret: Result<AssistantMessage, _> =
             serde_json::from_str(&valid_json);
         assert!(ret.is_ok());
+    }
+
+    #[test]
+    fn test_user_message_from_iter() {
+        // From an iterator of &str (via blanket Into<Block>).
+        let msg: UserMessage = ["Hello,", "world!"].into_iter().collect();
+        let Content::MultiPart(blocks) = msg.content() else {
+            panic!("expected MultiPart");
+        };
+        assert_eq!(blocks.len(), 2);
+
+        // From an iterator of tool::Result.
+        let results = vec![
+            tool::Result {
+                tool_use_id: "tool_1".into(),
+                content: "ok".into(),
+                is_error: false,
+                cache_control: None,
+            },
+            tool::Result {
+                tool_use_id: "tool_2".into(),
+                content: "parse error: ...".into(),
+                is_error: true,
+                cache_control: None,
+            },
+        ];
+        let msg: UserMessage = results.into_iter().collect();
+        let Content::MultiPart(blocks) = msg.content() else {
+            panic!("expected MultiPart");
+        };
+        assert_eq!(blocks.len(), 2);
+        assert!(matches!(blocks[0], Block::ToolResult { .. }));
+        assert!(matches!(blocks[1], Block::ToolResult { .. }));
+    }
+
+    #[test]
+    fn test_assistant_message_from_iter() {
+        let msg: AssistantMessage =
+            ["thinking...", "done."].into_iter().collect();
+        let Content::MultiPart(blocks) = msg.content() else {
+            panic!("expected MultiPart");
+        };
+        assert_eq!(blocks.len(), 2);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Adds `impl<'a, T: Into<Block<'a>>> FromIterator<T>` to both `UserMessage` and `AssistantMessage`, mirroring the existing impl on `Content`.
- Lets callers collect an iterator of `tool::Result` (or any `Into<Block>` source) straight into a role-typed message, which removes a lot of `Content::MultiPart(blocks)` boilerplate at call sites.

Motivated by an agora-seed refactor where every tool-processing function returns a `tool::Result` and the scheduler needs to push a single multi-part user message per turn. With this impl, that collapses to:

```rust
let reply: UserMessage = tool_results.into_iter().collect();
prompt.push_message(reply)?;
```

## Test plan

- [x] `cargo test -p misanthropic` — 171 passed, including two new tests (`test_user_message_from_iter`, `test_assistant_message_from_iter`) that cover collecting from `&str` and from `tool::Result`.
- [x] `rustfmt` clean on the touched file.
- [x] No new clippy findings from the added code (pre-existing dev-branch clippy errors in `response.rs` / `batch.rs` are untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)