### PR TITLE
prompt: Add cache_1h / cache_with variants for 1-hour cache TTL

### DIFF
--- a/misanthropic/src/prompt.rs
+++ b/misanthropic/src/prompt.rs
@@ -715,17 +715,37 @@ impl<'a> Prompt<'a> {
     /// [`Sonnet35`]: crate::Model::Sonnet35
     /// [`Opus30`]: crate::Model::Opus30
     /// [`Haiku30`]: crate::Model::Haiku30
-    pub fn cache(mut self) -> Self {
+    pub fn cache(self) -> Self {
+        self.cache_with(crate::prompt::message::CacheControl::ephemeral())
+    }
+
+    /// Add a 1-hour cache breakpoint on the last cacheable block.
+    ///
+    /// Behaves identically to [`cache`](Prompt::cache) but uses
+    /// [`CacheControl::one_hour`](crate::prompt::message::CacheControl::one_hour).
+    /// Useful when the priming write and the real requests may be
+    /// separated by more than the default 5-minute window.
+    pub fn cache_1h(self) -> Self {
+        self.cache_with(crate::prompt::message::CacheControl::one_hour())
+    }
+
+    /// Add a cache breakpoint with a caller-provided [`CacheControl`] on
+    /// the last cacheable block. Shared implementation for
+    /// [`cache`](Prompt::cache) and [`cache_1h`](Prompt::cache_1h).
+    pub fn cache_with(
+        mut self,
+        cache_control: crate::prompt::message::CacheControl,
+    ) -> Self {
         // If there are messages, add a cache breakpoint to the last one.
         if let Some(last) = self.messages.last_mut() {
-            last.content.cache();
+            last.content.cache_with(cache_control);
             return self;
         }
 
         // If there are no messages, add a cache breakpoint to the system prompt
         // if it exists.
         if let Some(system) = self.system.as_mut() {
-            system.cache();
+            system.cache_with(cache_control);
             return self;
         }
 
@@ -734,7 +754,7 @@ impl<'a> Prompt<'a> {
         if let Some(tool) =
             self.functions.as_mut().and_then(|tools| tools.last_mut())
         {
-            tool.cache();
+            tool.cache_with(cache_control);
             return self;
         }
 

--- a/misanthropic/src/prompt/cached.rs
+++ b/misanthropic/src/prompt/cached.rs
@@ -130,11 +130,26 @@ impl<'a> CachedPrompt<'a> {
     /// Call this after appending messages to extend the cached region.
     /// The API keeps only the last 4 breakpoints, so calling this every
     /// turn is safe.
+    ///
+    /// Uses the default 5-minute ephemeral TTL. For 1-hour TTL (useful
+    /// for cache priming across an hourly batch cadence), use
+    /// [`cache_1h`](CachedPrompt::cache_1h).
     pub fn cache(&mut self) {
         // Prompt::cache() is `fn cache(mut self) -> Self`, so we need to
         // temporarily take ownership.
         let taken = std::mem::take(&mut self.inner);
         self.inner = taken.cache();
+    }
+
+    /// Add a 1-hour cache breakpoint on the last cacheable block.
+    ///
+    /// Behaves identically to [`cache`](CachedPrompt::cache) but uses
+    /// [`CacheControl::one_hour`](crate::prompt::message::CacheControl::one_hour).
+    /// Useful when the priming write and the real requests may be
+    /// separated by more than the default 5-minute window.
+    pub fn cache_1h(&mut self) {
+        let taken = std::mem::take(&mut self.inner);
+        self.inner = taken.cache_1h();
     }
 
     /// Add a cache breakpoint on the last message, keeping at most `n`
@@ -323,6 +338,41 @@ mod tests {
             crate::prompt::message::Content::SinglePart(_) => {
                 panic!("expected MultiPart after cache()")
             }
+        }
+    }
+
+    #[test]
+    fn cache_1h_sets_one_hour_ttl() {
+        use crate::prompt::message::{CacheControl, CacheTtl};
+
+        let prompt = Prompt {
+            system: Some(crate::prompt::message::Content::text(
+                "You are a helpful assistant.",
+            )),
+            ..Default::default()
+        };
+
+        let mut cached = CachedPrompt::uncached(prompt);
+        cached.cache_1h();
+
+        // The system block should now carry a 1-hour cache_control.
+        match cached.system.as_ref().unwrap() {
+            crate::prompt::message::Content::MultiPart(blocks) => {
+                let last = blocks.last().unwrap();
+                let cc = match last {
+                    crate::prompt::message::Block::Text {
+                        cache_control, ..
+                    } => cache_control.as_ref().unwrap(),
+                    _ => panic!("expected text block"),
+                };
+                assert_eq!(
+                    cc,
+                    &CacheControl::Ephemeral {
+                        ttl: Some(CacheTtl::OneHour)
+                    }
+                );
+            }
+            _ => panic!("expected MultiPart after cache_1h()"),
         }
     }
 

--- a/misanthropic/src/prompt/message.rs
+++ b/misanthropic/src/prompt/message.rs
@@ -671,9 +671,30 @@ impl<'a> Content<'a> {
     /// Add a cache breakpoint to the final [`Block`]. If the [`Content`] is
     /// [`SinglePart`], it will be converted to [`MultiPart`] first.
     ///
+    /// Uses the default 5-minute ephemeral TTL. For a 1-hour TTL, use
+    /// [`cache_1h`](Content::cache_1h).
+    ///
     /// [`SinglePart`]: Content::SinglePart
     /// [`MultiPart`]: Content::MultiPart
     pub fn cache(&mut self) {
+        self.cache_with(CacheControl::ephemeral());
+    }
+
+    /// Add a 1-hour cache breakpoint to the final [`Block`].
+    ///
+    /// Behaves identically to [`cache`](Content::cache) but uses
+    /// [`CacheControl::one_hour`].
+    pub fn cache_1h(&mut self) {
+        self.cache_with(CacheControl::one_hour());
+    }
+
+    /// Add a cache breakpoint with a caller-provided [`CacheControl`] to
+    /// the final [`Block`]. If the [`Content`] is [`SinglePart`], it will
+    /// be converted to [`MultiPart`] first.
+    ///
+    /// [`SinglePart`]: Content::SinglePart
+    /// [`MultiPart`]: Content::MultiPart
+    pub fn cache_with(&mut self, cache_control: CacheControl) {
         if self.is_single_part() {
             let mut old = Content::MultiPart(vec![]);
             std::mem::swap(self, &mut old);
@@ -683,7 +704,7 @@ impl<'a> Content<'a> {
         if let Content::MultiPart(parts) = self
             && let Some(block) = parts.last_mut()
         {
-            block.cache();
+            block.cache_with(cache_control);
         }
     }
 
@@ -1271,8 +1292,28 @@ impl<'a> Block<'a> {
     /// information. Returns true if the block was cached. This alwasy succeeds,
     /// however some blocks are automatically cached and will return false.
     ///
+    /// Uses the default 5-minute ephemeral TTL. For a 1-hour TTL, use
+    /// [`cache_1h`](Block::cache_1h).
+    ///
     /// [`Prompt::cache`]: crate::Prompt::cache
     pub fn cache(&mut self) -> bool {
+        self.cache_with(CacheControl::ephemeral())
+    }
+
+    /// Create a 1-hour cache breakpoint at this block.
+    ///
+    /// Behaves identically to [`cache`](Block::cache) but uses
+    /// [`CacheControl::one_hour`]. See [`Prompt::cache_1h`] for usage.
+    ///
+    /// [`Prompt::cache_1h`]: crate::Prompt::cache_1h
+    pub fn cache_1h(&mut self) -> bool {
+        self.cache_with(CacheControl::one_hour())
+    }
+
+    /// Create a cache breakpoint at this block with a caller-provided
+    /// [`CacheControl`]. Returns true if the block was cached; returns
+    /// false for thought blocks (which are automatically cached).
+    pub fn cache_with(&mut self, cache_control_value: CacheControl) -> bool {
         use crate::tool;
 
         match self {
@@ -1284,7 +1325,7 @@ impl<'a> Block<'a> {
             | Self::ToolResult {
                 result: tool::Result { cache_control, .. },
             } => {
-                *cache_control = Some(CacheControl::ephemeral());
+                *cache_control = Some(cache_control_value);
 
                 true
             }

--- a/misanthropic/src/tool.rs
+++ b/misanthropic/src/tool.rs
@@ -522,12 +522,30 @@ impl<'a> Method<'a> {
     /// Create a cache breakpoint at this [`Method`] by setting [`cache_control`]
     /// to [`Ephemeral`] See [`Prompt::cache`] for more information.
     ///
+    /// Uses the default 5-minute TTL. For a 1-hour TTL, use
+    /// [`cache_1h`](Self::cache_1h).
+    ///
     /// [`cache_control`]: Self::cache_control
     /// [`Ephemeral`]: crate::prompt::message::CacheControl::Ephemeral
     /// [`Prompt::cache`]: crate::prompt::Prompt::cache
     pub fn cache(&mut self) -> &mut Self {
-        self.cache_control =
-            Some(crate::prompt::message::CacheControl::ephemeral());
+        self.cache_with(crate::prompt::message::CacheControl::ephemeral())
+    }
+
+    /// Create a 1-hour cache breakpoint at this [`Method`]. Behaves
+    /// identically to [`cache`](Self::cache) but uses
+    /// [`CacheControl::one_hour`](crate::prompt::message::CacheControl::one_hour).
+    pub fn cache_1h(&mut self) -> &mut Self {
+        self.cache_with(crate::prompt::message::CacheControl::one_hour())
+    }
+
+    /// Create a cache breakpoint at this [`Method`] with a caller-provided
+    /// [`CacheControl`](crate::prompt::message::CacheControl).
+    pub fn cache_with(
+        &mut self,
+        cache_control: crate::prompt::message::CacheControl,
+    ) -> &mut Self {
+        self.cache_control = Some(cache_control);
         self
     }
 


### PR DESCRIPTION
## Summary

- Adds \`cache_1h\` variants at every layer (Block, Content, Prompt, CachedPrompt, tool::Spec) that mirror the existing \`cache\` methods but use \`CacheControl::one_hour\` instead of \`ephemeral\`.
- Refactors existing \`cache\` methods to delegate to new \`cache_with(CacheControl)\` methods, so the 5m / 1h split is just a shared implementation + two thin wrappers. Source-compatible — no existing call sites change.
- Uses the already-exposed \`CacheControl::one_hour()\` constructor — no new serialization, no new enum variants.

## Motivation

The 5-minute TTL is fine for interactive chat, but for cache priming where a priming write and the real follow-up batches may be separated by more than 5 minutes, you need the 1-hour TTL. Before this change there was no way to set that through the \`CachedPrompt\` / \`Prompt\` API — callers would have had to fall through to \`into_inner\` and manipulate \`cache_control\` on the underlying blocks by hand.

## Test plan

- [x] New unit test \`cache_1h_sets_one_hour_ttl\` — verifies the 1h \`CacheControl\` is written to the expected block
- [x] Full misanthropic test suite green (178 passed, 6 ignored)

🤖 Generated with [Claude Code](https://claude.com/claude-code)