### PR TITLE
batch: Add Clone impls for Pending<P> and Prompts<P> where P: Clone

### DIFF
--- a/misanthropic/src/batch.rs
+++ b/misanthropic/src/batch.rs
@@ -33,6 +33,14 @@ pub struct Prompts<P> {
     pub(crate) prompts: HashMap<Id, P>,
 }
 
+impl<P: Clone> Clone for Prompts<P> {
+    fn clone(&self) -> Self {
+        Self {
+            prompts: self.prompts.clone(),
+        }
+    }
+}
+
 impl<P> std::fmt::Debug for Prompts<P> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.write_str(concat!(stringify!(Prompts), " { ... }"))
@@ -320,6 +328,15 @@ impl<P: Serialize> Serialize for Batch<P> {
 pub struct Pending<P> {
     pub(crate) prompts: Prompts<P>,
     pub(crate) meta: Meta,
+}
+
+impl<P: Clone> Clone for Pending<P> {
+    fn clone(&self) -> Self {
+        Self {
+            prompts: self.prompts.clone(),
+            meta: self.meta.clone(),
+        }
+    }
 }
 
 // Manual Serialize: only needed when P: Serialize (for submitting).


### PR DESCRIPTION
## Summary

- Adds \`impl<P: Clone> Clone for Prompts<P>\` and \`impl<P: Clone> Clone for Pending<P>\`.
- Enables callers to retry \`tagged_batch\` / \`batch_poll\` around transient edge failures without losing in-flight batch state.

## Motivation

\`batch_poll(pending)\` takes \`Pending<P>\` by value and consumes it on error. A caller wrapping it in a retry loop previously had no way to reconstruct the input for a second attempt. Same shape for \`tagged_batch\` taking the prompts \`Vec\` by value.

Bounded \`Clone\` is the minimal intervention: consumers whose \`P\` isn't \`Clone\` are unaffected, and the existing API stays source-compatible. The alternative would be to return \`(Pending<P>, Error)\` on failure, which is a larger API change.

## Test plan

- [x] Full misanthropic test suite green (178 passed, 6 ignored)
- [ ] Downstream agora-appeals wraps \`tagged_batch\` / \`batch_poll\` in \`retry_recoverable\` (in progress)

🤖 Generated with [Claude Code](https://claude.com/claude-code)