### PR TITLE
prompt/tool: Drop non_exhaustive from Prompt and Method

### DIFF
--- a/misanthropic/src/client.rs
+++ b/misanthropic/src/client.rs
@@ -738,6 +738,7 @@ impl From<Key> for Client {
 /// [`Error::NonJsonResponse`] and debug logs. Bodies longer than this are
 /// truncated with a `... [N more bytes]` suffix so operators still know
 /// how much content was elided.
+#[cfg(any(feature = "client", test))]
 const NON_JSON_BODY_SNIPPET_LEN: usize = 2048;
 
 /// Read `response` body as text and parse it as JSON, logging the raw
@@ -782,6 +783,7 @@ where
 /// Truncate `body` to at most [`NON_JSON_BODY_SNIPPET_LEN`] bytes at a
 /// valid UTF-8 boundary, appending a `... [N more bytes]` suffix if the
 /// body was longer.
+#[cfg(any(feature = "client", test))]
 fn truncate_body(body: &str) -> std::borrow::Cow<'_, str> {
     if body.len() <= NON_JSON_BODY_SNIPPET_LEN {
         return std::borrow::Cow::Borrowed(body);

--- a/misanthropic/src/prompt.rs
+++ b/misanthropic/src/prompt.rs
@@ -37,7 +37,6 @@ pub use output::{JsonSchemaFormat, OutputConfig, OutputFormat};
 #[derive(Serialize, Deserialize, Clone)]
 #[cfg_attr(any(feature = "partial-eq", test), derive(PartialEq))]
 #[serde(default)]
-#[non_exhaustive]
 pub struct Prompt<'a> {
     /// [`Model`] to use for inference.
     pub model: model::Id<'a>,

--- a/misanthropic/src/tool.rs
+++ b/misanthropic/src/tool.rs
@@ -131,7 +131,6 @@ static_assertions::assert_impl_all!(dyn Tool: Send);
 #[derive(Clone, Debug, Serialize, Deserialize, Hash)]
 #[serde(try_from = "MethodBuilder<'a>")]
 #[serde(rename = "tool")]
-#[non_exhaustive]
 pub struct Method<'a> {
     /// Name of the function. This should be in a `Tool::function` format.
     pub name: Cow<'a, str>,


### PR DESCRIPTION
## Summary

- Removes `#[non_exhaustive]` from `Prompt` and `Method` so downstream
  crates can construct them with struct-literal syntax (`Prompt { model,
  system, messages, ..default() }`). This is the canonical pattern in
  the examples and in downstream integration tests (drama_llama);
  `#[non_exhaustive]` currently breaks all of them with `E0639`.
- Keeps `#[non_exhaustive]` on the newly-landed `OutputConfig`,
  `OutputFormat`, and `JsonSchemaFormat` — those types will grow
  variants and aren't constructed with struct-literal syntax downstream.
- Small cfg fix: gate `truncate_body` + `NON_JSON_BODY_SNIPPET_LEN` on
  `cfg(any(feature = "client", test))`. Without this, building with
  `--no-default-features --features partial-eq` (drama_llama's combo)
  trips `#[deny(warnings)]` on unused dead code, because the only non-test
  callers live under `cfg(feature = "client")` already.

## Rationale

`#[non_exhaustive]` on these types was intended to preserve room for
non-breaking field additions post-1.0. Since we're still
`1.0.0-alpha.1`, the semver protection is mostly theoretical — and in
practice it forces every downstream consumer either onto a
`Default::default()`-plus-field-assign dance or the builder path. The
ergonomic cost outweighs the benefit at this pre-1.0 stage; the
attribute can be restored at the real 1.0 boundary alongside a proper
migration to `MethodBuilder` / a `Prompt` builder.

## Test plan

- [x] `cargo check -p misanthropic --no-default-features --features partial-eq` — clean
- [x] `cargo check -p misanthropic --no-default-features --features partial-eq,client` — clean
- [x] `cargo test -p misanthropic --no-default-features --features partial-eq --no-run` — clean
- [x] Downstream drama_llama `cargo check --tests --features "webchat,cli,stats,toml,serde,egui"` compiles against this branch via `[patch]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)