### PR TITLE
Content newtype + prompt::index API

### DIFF
--- a/chat/frontend/src/views/chat.rs
+++ b/chat/frontend/src/views/chat.rs
@@ -70,6 +70,7 @@ fn make_prompt() -> Prompt<'static> {
                 "required": ["script"],
             }),
             cache_control: None,
+            strict: Some(true)
         })
         // Inform the assistant about their limitations.
         .set_system(include_str!("../../../../misanthropic/examples/python_system.md"))

--- a/chat/frontend/src/views/chat.rs
+++ b/chat/frontend/src/views/chat.rs
@@ -93,7 +93,7 @@ fn make_prompt() -> Prompt<'static> {
             },
             Message {
                 role: Role::Assistant,
-                content: Content::MultiPart(vec![
+                content: Content(vec![
                     // Regular, plain old, legacy thinking block. When displayed
                     // with `ThoughtsOrSpeech`, it will be styled as a thought.
                     r#"<thinking>I can't do that myself, but I can run a Python script to count the number of r's in "strawberry". The user did not specify case sensitivity so I will default to case insensitive.</thinking>"#.into(),
@@ -117,7 +117,7 @@ fn make_prompt() -> Prompt<'static> {
             (Role::User, "List the permutations of the first four letters of the alphabet.").into(),
             Message {
                 role: Role::Assistant,
-                content: Content::MultiPart(vec![
+                content: Content(vec![
                     // Anthropic provided `Thought` blocks should have the same
                     // exact styling as the Assistant's thoughts. So now "old"
                     // models have feature parity with the new ones, at least

--- a/misanthropic/Cargo.toml
+++ b/misanthropic/Cargo.toml
@@ -30,6 +30,7 @@ base64 = "0.22"
 derive_more = { version = "1", features = [
     "as_ref",
     "deref",
+    "deref_mut",
     "display",
     "from",
     "into",

--- a/misanthropic/examples/python.rs
+++ b/misanthropic/examples/python.rs
@@ -227,7 +227,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             },
             Message {
                 role: Role::Assistant,
-                content: Content::MultiPart(vec![
+                content: Content(vec![
                     r#"<thinking>I can't do that myself, but I can run a Python script to count the number of r's in "strawberry". The user did not specify case sensitivity so I will default to case insensitive.</thinking>"#.into(),
                     tool::Use {
                         id: "calibration_000".into(),
@@ -249,7 +249,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             (Role::User, "List the permutations of the first four letters of the alphabet.").into(),
             Message {
                 role: Role::Assistant,
-                content: Content::MultiPart(vec![
+                content: Content(vec![
                     r#"<thinking>This request is complex enough to need Python. I should use the itertools module for this.</thinking>"#.into(),
                     tool::Use {
                         id: "calibration_001".into(),

--- a/misanthropic/src/cot.rs
+++ b/misanthropic/src/cot.rs
@@ -286,16 +286,9 @@ impl<'a> Thinkable<'a> for Content<'a> {
         start_tags: &'static [&'static str],
         end_tags: &'static [&'static str],
     ) -> Box<dyn Iterator<Item = ThoughtOrSpeech<'a>> + 'a> {
-        match self {
-            Content::SinglePart(cow_str) => Box::new(Box::new(
-                ThoughtsAndSpeech::new_custom(cow_str, start_tags, end_tags),
-            )),
-            Content::MultiPart(blocks) => {
-                Box::new(blocks.iter().flat_map(move |block| {
-                    block.thoughts_and_speech_custom(start_tags, end_tags)
-                }))
-            }
-        }
+        Box::new(self.iter().flat_map(move |block| {
+            block.thoughts_and_speech_custom(start_tags, end_tags)
+        }))
     }
 }
 

--- a/misanthropic/src/dioxus.rs
+++ b/misanthropic/src/dioxus.rs
@@ -449,27 +449,14 @@ impl IntoElement for &Block<'_> {
 
 impl IntoElement for &message::Content<'_> {
     fn into_element_custom(self, key: u64, opts: &Options) -> Element {
-        match self {
-            message::Content::SinglePart(text) => {
-                rsx!(div {
-                    key: key,
-                    class: "single-part",
-                    {ThoughtsAndSpeech::new(text.as_ref())
-                        .enumerate()
-                        .map(|(i, ts)| ts.into_element_custom(hash(&[key, i as u64]), opts))}
-                })
-            }
-            message::Content::MultiPart(blocks) => {
-                rsx!(div {
-                    key: key,
-                    class: "multi-part",
-                    {blocks
-                        .iter()
-                        .enumerate()
-                        .map(|(i, block)| block.into_element_custom(hash(&[key, i as u64]), opts))}
-                })
-            }
-        }
+        rsx!(div {
+            key: key,
+            class: "multi-part",
+            {self
+                .iter()
+                .enumerate()
+                .map(|(i, block)| block.into_element_custom(hash(&[key, i as u64]), opts))}
+        })
     }
 }
 
@@ -490,58 +477,37 @@ impl IntoElement for &message::Message<'_> {
             // This has to be implemented here and not in content because we
             // need to know the role. This is unfortunate because it's a bit
             // ugly.
-            {match &self.content {
-                    message::Content::SinglePart(text) => {
+            {if self.role.is_user() {
+                // Users have no thoughts; gate their speech per options.
+                match &opts.speech {
+                    opts::Speech::Hidden => rsx!(),
+                    opts::Speech::Placeholder { class } => {
                         rsx!(div {
-                            key: key,
-                            class: "single-part",
-                            {if self.role.is_user() {
-                                match &opts.speech {
-                                    opts::Speech::Hidden => rsx!(),
-                                    opts::Speech::Placeholder { class } => {
-                                        rsx!(div {
-                                            key: hash(&[key, 0]),
-                                            class: class.as_ref(),
-                                        })
-                                    }
-                                    opts::Speech::Show { class } => {
-                                        rsx!(div {
-                                            key: hash(&[key, 0]),
-                                            class: class.as_ref(),
-                                            {text}
-                                        })
-                                    }
-                                }
-                            } else {
-                                rsx!(
-                                    div {
-                                        key: hash(&[key, 0]),
-                                        class: "assistant",
-                                        {ThoughtsAndSpeech::new(text.as_ref())
-                                            .enumerate()
-                                            .map(|(i, ts)| ts.into_element_custom(hash(&[key, i as u64]), opts))}
-                                    }
-                                )
-                            }}
+                            key: hash(&[key, 0]),
+                            class: class.as_ref(),
                         })
                     }
-                    message::Content::MultiPart(blocks) => {
+                    opts::Speech::Show { class } => {
                         rsx!(div {
                             key: key,
-                            class: "multi-part",
-                            {blocks
+                            class: class.as_ref(),
+                            {self.content
                                 .iter()
                                 .enumerate()
-                                .map(|(i, block)| {
-                                    block.into_element_custom(
-                                        hash(&[key, i as u64]),
-                                        opts
-                                    )
-                                })}
+                                .map(|(i, block)| block.into_element_custom(hash(&[key, i as u64]), opts))}
                         })
                     }
                 }
-            }
+            } else {
+                rsx!(div {
+                    key: key,
+                    class: "multi-part",
+                    {self.content
+                        .iter()
+                        .enumerate()
+                        .map(|(i, block)| block.into_element_custom(hash(&[key, i as u64]), opts))}
+                })
+            }}
         })
     }
 }

--- a/misanthropic/src/openai.rs
+++ b/misanthropic/src/openai.rs
@@ -400,7 +400,7 @@ impl ChatStreamAccumulator {
 
         Some(Message {
             role: Role::Assistant,
-            content: Content::MultiPart(blocks),
+            content: Content(blocks),
         })
     }
 }
@@ -535,21 +535,16 @@ impl ChatCompletionResponse {
 /// Extract the text content from a misanthropic [`Content`], ignoring
 /// non-text blocks.
 fn content_to_text(content: &Content<'_>) -> String {
-    match content {
-        Content::SinglePart(text) => text.to_string(),
-        Content::MultiPart(blocks) => {
-            let mut out = String::new();
-            for block in blocks {
-                if let Block::Text { text, .. } = block {
-                    if !out.is_empty() {
-                        out.push('\n');
-                    }
-                    out.push_str(text);
-                }
+    let mut out = String::new();
+    for block in content.iter() {
+        if let Block::Text { text, .. } = block {
+            if !out.is_empty() {
+                out.push('\n');
             }
-            out
+            out.push_str(text);
         }
     }
+    out
 }
 
 /// Convert a misanthropic [`Message`] into one or more [`ChatMessage`]s.
@@ -558,124 +553,113 @@ fn content_to_text(content: &Content<'_>) -> String {
 /// produce multiple OpenAI messages, because tool results must be separate
 /// messages with `role: "tool"`.
 fn message_to_chat_messages<'a>(msg: &Message<'a>) -> Vec<ChatMessage> {
-    match &msg.content {
-        Content::SinglePart(text) => vec![ChatMessage {
-            role: role_to_chat_role(msg.role),
-            content: Some(ChatContent::Text(text.to_string())),
-            tool_calls: None,
-            tool_call_id: None,
-            name: None,
-        }],
-        Content::MultiPart(blocks) => {
-            let mut text_parts = Vec::new();
-            let mut image_parts = Vec::new();
-            let mut tool_calls = Vec::new();
-            let mut tool_results = Vec::new();
+    let mut text_parts = Vec::new();
+    let mut image_parts = Vec::new();
+    let mut tool_calls = Vec::new();
+    let mut tool_results = Vec::new();
 
-            for block in blocks {
-                match block {
-                    Block::Text { text, .. } => {
-                        text_parts.push(text.to_string());
-                    }
-                    Block::Image { image, .. } => {
-                        let Image::Base64 {
-                            media_type, data, ..
-                        } = image;
-                        let mt = match media_type {
-                            MediaType::Jpeg => "image/jpeg",
-                            MediaType::Png => "image/png",
-                            MediaType::Gif => "image/gif",
-                            MediaType::Webp => "image/webp",
-                        };
-                        let data_url = format!("data:{};base64,{}", mt, data);
-                        image_parts.push(ChatContentPart::ImageUrl {
-                            image_url: ImageUrl {
-                                url: data_url,
-                                detail: None,
-                            },
-                        });
-                    }
-                    Block::ToolUse { call } => {
-                        tool_calls.push(ChatToolCall {
-                            id: call.id.to_string(),
-                            kind: "function".to_string(),
-                            function: ChatFunctionCall {
-                                name: call.name.to_string(),
-                                arguments: serde_json::to_string(&call.input)
-                                    .unwrap_or_default(),
-                            },
-                        });
-                    }
-                    Block::ToolResult { result } => {
-                        tool_results.push(ChatMessage {
-                            role: ChatRole::Tool,
-                            content: Some(ChatContent::Text(content_to_text(
-                                &result.content,
-                            ))),
-                            tool_calls: None,
-                            tool_call_id: Some(result.tool_use_id.to_string()),
-                            name: None,
-                        });
-                    }
-                    // Thought blocks have no OpenAI equivalent — skip them
-                    Block::Thought { .. } | Block::RedactedThought { .. } => {}
-                }
+    for block in msg.content.iter() {
+        match block {
+            Block::Text { text, .. } => {
+                text_parts.push(text.to_string());
             }
-
-            let mut messages = Vec::new();
-
-            // Build the primary message
-            if msg.role == Role::Assistant {
-                // Assistant: text content + optional tool calls
-                let content = if text_parts.is_empty() {
-                    None
-                } else {
-                    Some(ChatContent::Text(text_parts.join("\n")))
+            Block::Image { image, .. } => {
+                let Image::Base64 {
+                    media_type, data, ..
+                } = image;
+                let mt = match media_type {
+                    MediaType::Jpeg => "image/jpeg",
+                    MediaType::Png => "image/png",
+                    MediaType::Gif => "image/gif",
+                    MediaType::Webp => "image/webp",
                 };
-                let calls = if tool_calls.is_empty() {
-                    None
-                } else {
-                    Some(tool_calls)
-                };
-                messages.push(ChatMessage {
-                    role: ChatRole::Assistant,
-                    content,
-                    tool_calls: calls,
-                    tool_call_id: None,
+                let data_url = format!("data:{};base64,{}", mt, data);
+                image_parts.push(ChatContentPart::ImageUrl {
+                    image_url: ImageUrl {
+                        url: data_url,
+                        detail: None,
+                    },
+                });
+            }
+            Block::ToolUse { call } => {
+                tool_calls.push(ChatToolCall {
+                    id: call.id.to_string(),
+                    kind: "function".to_string(),
+                    function: ChatFunctionCall {
+                        name: call.name.to_string(),
+                        arguments: serde_json::to_string(&call.input)
+                            .unwrap_or_default(),
+                    },
+                });
+            }
+            Block::ToolResult { result } => {
+                tool_results.push(ChatMessage {
+                    role: ChatRole::Tool,
+                    content: Some(ChatContent::Text(content_to_text(
+                        &result.content,
+                    ))),
+                    tool_calls: None,
+                    tool_call_id: Some(result.tool_use_id.to_string()),
                     name: None,
                 });
-            } else {
-                // User: may have text + images
-                if !image_parts.is_empty() {
-                    let mut parts: Vec<ChatContentPart> = text_parts
-                        .iter()
-                        .map(|t| ChatContentPart::Text { text: t.clone() })
-                        .collect();
-                    parts.extend(image_parts);
-                    messages.push(ChatMessage {
-                        role: ChatRole::User,
-                        content: Some(ChatContent::Parts(parts)),
-                        tool_calls: None,
-                        tool_call_id: None,
-                        name: None,
-                    });
-                } else if !text_parts.is_empty() {
-                    messages.push(ChatMessage {
-                        role: role_to_chat_role(msg.role),
-                        content: Some(ChatContent::Text(text_parts.join("\n"))),
-                        tool_calls: None,
-                        tool_call_id: None,
-                        name: None,
-                    });
-                }
             }
-
-            // Tool results become separate messages
-            messages.extend(tool_results);
-
-            messages
+            // Thought blocks have no OpenAI equivalent — skip them
+            Block::Thought { .. } | Block::RedactedThought { .. } => {}
         }
     }
+
+    let mut messages = Vec::new();
+
+    // Build the primary message
+    if msg.role == Role::Assistant {
+        // Assistant: text content + optional tool calls
+        let content = if text_parts.is_empty() {
+            None
+        } else {
+            Some(ChatContent::Text(text_parts.join("\n")))
+        };
+        let calls = if tool_calls.is_empty() {
+            None
+        } else {
+            Some(tool_calls)
+        };
+        messages.push(ChatMessage {
+            role: ChatRole::Assistant,
+            content,
+            tool_calls: calls,
+            tool_call_id: None,
+            name: None,
+        });
+    } else {
+        // User: may have text + images
+        if !image_parts.is_empty() {
+            let mut parts: Vec<ChatContentPart> = text_parts
+                .iter()
+                .map(|t| ChatContentPart::Text { text: t.clone() })
+                .collect();
+            parts.extend(image_parts);
+            messages.push(ChatMessage {
+                role: ChatRole::User,
+                content: Some(ChatContent::Parts(parts)),
+                tool_calls: None,
+                tool_call_id: None,
+                name: None,
+            });
+        } else if !text_parts.is_empty() {
+            messages.push(ChatMessage {
+                role: role_to_chat_role(msg.role),
+                content: Some(ChatContent::Text(text_parts.join("\n"))),
+                tool_calls: None,
+                tool_call_id: None,
+                name: None,
+            });
+        }
+    }
+
+    // Tool results become separate messages
+    messages.extend(tool_results);
+
+    messages
 }
 
 /// Convert a [`ChatMessage`] into a misanthropic [`Message`].
@@ -726,22 +710,9 @@ fn chat_message_to_message(msg: ChatMessage) -> Message<'static> {
         _ => Role::User,
     };
 
-    if blocks.len() == 1 {
-        if let Block::Text { text, .. } = &blocks[0] {
-            return Message {
-                role,
-                content: Content::SinglePart(text.clone()),
-            };
-        }
-    }
-
     Message {
         role,
-        content: if blocks.is_empty() {
-            Content::SinglePart(CowStr::from(String::new()))
-        } else {
-            Content::MultiPart(blocks)
-        },
+        content: Content(blocks),
     }
 }
 
@@ -763,10 +734,10 @@ mod tests {
             model: "claude-sonnet-4-20250514".into(),
             messages: vec![Message {
                 role: Role::User,
-                content: Content::SinglePart("Hello".into()),
+                content: Content::text("Hello"),
             }],
             max_tokens: NonZeroU32::new(1024).unwrap(),
-            system: Some(Content::SinglePart("You are helpful.".into())),
+            system: Some(Content::text("You are helpful.")),
             ..Default::default()
         };
 
@@ -841,7 +812,7 @@ mod tests {
     fn tool_result_to_chat_message() {
         let result = tool::Result {
             tool_use_id: Cow::Borrowed("call_456"),
-            content: Content::SinglePart("Sunny, 22°C".into()),
+            content: Content::text("Sunny, 22°C"),
             is_error: false,
             cache_control: None,
         };
@@ -877,10 +848,11 @@ mod tests {
 
         let msg = resp.into_message().unwrap();
         assert_eq!(msg.role, Role::Assistant);
-        if let Content::SinglePart(text) = &msg.content {
+        assert_eq!(msg.content.len(), 1);
+        if let Some(Block::Text { text, .. }) = msg.content.first() {
             assert_eq!(text.to_string(), "Hello!");
         } else {
-            panic!("expected single part");
+            panic!("expected a text block");
         }
     }
 
@@ -921,7 +893,7 @@ mod tests {
     fn thought_blocks_stripped() {
         let msg = Message {
             role: Role::Assistant,
-            content: Content::MultiPart(vec![
+            content: Content(vec![
                 Block::Thought {
                     thought: "thinking...".into(),
                     signature: "sig".into(),
@@ -977,14 +949,10 @@ mod tests {
 
         assert_eq!(acc.finish_reason(), Some("stop"));
         let msg = acc.into_message().unwrap();
-        if let Content::MultiPart(blocks) = &msg.content {
-            if let Block::Text { text, .. } = &blocks[0] {
-                assert_eq!(text.to_string(), "Hello world!");
-            } else {
-                panic!("expected text block");
-            }
+        if let Some(Block::Text { text, .. }) = msg.content.first() {
+            assert_eq!(text.to_string(), "Hello world!");
         } else {
-            panic!("expected multipart");
+            panic!("expected text block");
         }
     }
 

--- a/misanthropic/src/prompt.rs
+++ b/misanthropic/src/prompt.rs
@@ -72,10 +72,8 @@ pub struct Prompt<'a> {
     /// [`response::Message`]: crate::response::Message
     #[serde(skip_serializing_if = "Option::is_none")]
     pub stream: Option<bool>,
-    /// System prompt as [`SinglePart`] or [`MultiPart`] [`Content`].
+    /// System prompt as [`Content`].
     ///
-    /// [`SinglePart`]: message::Content::SinglePart
-    /// [`MultiPart`]: message::Content::MultiPart
     /// [`Content`]: message::Content
     #[serde(skip_serializing_if = "Option::is_none")]
     pub system: Option<message::Content<'a>>,
@@ -587,8 +585,7 @@ impl<'a> Prompt<'a> {
                 self.system = Some(content);
             }
             None => {
-                // MultiPart doesn't actually need to have multiple parts.
-                self.system = Some(Content::MultiPart(vec![block.into()]));
+                self.system = Some(Content(vec![block.into()]));
             }
         }
         self
@@ -1525,11 +1522,20 @@ mod tests {
             .unwrap()
             .cache();
 
-        // The first message should still be a single part string.
-        assert!(request.messages.first().unwrap().content.last().is_none());
+        // The first message should not be cached — cache() only touches the
+        // last message.
+        assert!(
+            !request
+                .messages
+                .first()
+                .unwrap()
+                .content
+                .last()
+                .unwrap()
+                .is_cached()
+        );
 
-        // By now the final part should be a multi part string, since only
-        // Block has `cache_control`
+        // The last message's final block should now be cached.
         assert!(
             request
                 .messages

--- a/misanthropic/src/prompt.rs
+++ b/misanthropic/src/prompt.rs
@@ -31,6 +31,9 @@ pub use cached::CachedPrompt;
 pub mod output;
 pub use output::{JsonSchemaFormat, OutputConfig, OutputFormat};
 
+pub mod index;
+pub use index::{BlockIndex, Index, IndexMut, IndexRef, MethodIndex};
+
 /// Request for the [Anthropic Messages API].
 ///
 /// [Anthropic Messages API]: <https://docs.anthropic.com/en/api/messages>

--- a/misanthropic/src/prompt/cached.rs
+++ b/misanthropic/src/prompt/cached.rs
@@ -332,11 +332,10 @@ impl<'a> CachedPrompt<'a> {
         let system_count = usize::from(
             self.inner.system.as_ref().is_some_and(|s| s.has_cache()),
         );
-        let tool_count = self
-            .inner
-            .functions
-            .as_ref()
-            .map_or(0, |tools| tools.iter().filter(|t| t.is_cached()).count());
+        let tool_count =
+            self.inner.functions.as_ref().map_or(0, |tools| {
+                tools.iter().filter(|t| t.is_cached()).count()
+            });
         let used = system_count + tool_count + tail_set.len();
         let non_tail_budget =
             MAX_CACHE_CONTROLS_PER_REQUEST.saturating_sub(used);
@@ -478,10 +477,10 @@ mod tests {
 
         let cached = CachedPrompt::from(prompt);
 
-        // System should still be SinglePart — From does not call .cache().
+        // From must not add a cache breakpoint.
         assert!(
-            cached.system.as_ref().unwrap().is_single_part(),
-            "expected SinglePart (From must not add a breakpoint)"
+            !cached.system.as_ref().unwrap().has_cache(),
+            "From must not add a breakpoint"
         );
     }
 
@@ -500,22 +499,14 @@ mod tests {
 
         // The system block should now carry a 5-minute cache_control.
         // (cache() falls through: no messages → caches system)
-        match cached.system.as_ref().unwrap() {
-            crate::prompt::message::Content::MultiPart(blocks) => {
-                let last = blocks.last().unwrap();
-                let cc = match last {
-                    crate::prompt::message::Block::Text {
-                        cache_control,
-                        ..
-                    } => cache_control.as_ref().unwrap(),
-                    _ => panic!("expected text block"),
-                };
-                assert_eq!(cc, &CacheControl::Ephemeral { ttl: None });
+        let last = cached.system.as_ref().unwrap().last().unwrap();
+        let cc = match last {
+            crate::prompt::message::Block::Text { cache_control, .. } => {
+                cache_control.as_ref().unwrap()
             }
-            crate::prompt::message::Content::SinglePart(_) => {
-                panic!("expected MultiPart after cached()")
-            }
-        }
+            _ => panic!("expected text block"),
+        };
+        assert_eq!(cc, &CacheControl::Ephemeral { ttl: None });
     }
 
     #[test]
@@ -532,25 +523,19 @@ mod tests {
         let cached = CachedPrompt::cached_1h(prompt);
 
         // The system block should now carry a 1-hour cache_control.
-        match cached.system.as_ref().unwrap() {
-            crate::prompt::message::Content::MultiPart(blocks) => {
-                let last = blocks.last().unwrap();
-                let cc = match last {
-                    crate::prompt::message::Block::Text {
-                        cache_control,
-                        ..
-                    } => cache_control.as_ref().unwrap(),
-                    _ => panic!("expected text block"),
-                };
-                assert_eq!(
-                    cc,
-                    &CacheControl::Ephemeral {
-                        ttl: Some(CacheTtl::OneHour)
-                    }
-                );
+        let last = cached.system.as_ref().unwrap().last().unwrap();
+        let cc = match last {
+            crate::prompt::message::Block::Text { cache_control, .. } => {
+                cache_control.as_ref().unwrap()
             }
-            _ => panic!("expected MultiPart after cached_1h()"),
-        }
+            _ => panic!("expected text block"),
+        };
+        assert_eq!(
+            cc,
+            &CacheControl::Ephemeral {
+                ttl: Some(CacheTtl::OneHour)
+            }
+        );
     }
 
     /// Regression test for a bug where the old `From<Prompt> for
@@ -566,7 +551,7 @@ mod tests {
         use crate::prompt::message::{Block, CacheControl, CacheTtl, Content};
 
         let prompt = Prompt {
-            system: Some(Content::MultiPart(vec![Block::Text {
+            system: Some(Content(vec![Block::Text {
                 text: "You are a helpful assistant.".into(),
                 cache_control: Some(CacheControl::one_hour()),
             }])),
@@ -575,24 +560,19 @@ mod tests {
 
         let cached = CachedPrompt::from(prompt);
 
-        match cached.system.as_ref().unwrap() {
-            Content::MultiPart(blocks) => {
-                let cc = match blocks.last().unwrap() {
-                    Block::Text { cache_control, .. } => {
-                        cache_control.as_ref().unwrap()
-                    }
-                    _ => panic!("expected text block"),
-                };
-                assert_eq!(
-                    cc,
-                    &CacheControl::Ephemeral {
-                        ttl: Some(CacheTtl::OneHour)
-                    },
-                    "From must preserve the inline 1h marker unchanged"
-                );
+        let cc = match cached.system.as_ref().unwrap().last().unwrap() {
+            Block::Text { cache_control, .. } => {
+                cache_control.as_ref().unwrap()
             }
-            _ => panic!("expected MultiPart"),
-        }
+            _ => panic!("expected text block"),
+        };
+        assert_eq!(
+            cc,
+            &CacheControl::Ephemeral {
+                ttl: Some(CacheTtl::OneHour)
+            },
+            "From must preserve the inline 1h marker unchanged"
+        );
     }
 
     #[test]
@@ -610,25 +590,19 @@ mod tests {
         cached.cache_1h();
 
         // The system block should now carry a 1-hour cache_control.
-        match cached.system.as_ref().unwrap() {
-            crate::prompt::message::Content::MultiPart(blocks) => {
-                let last = blocks.last().unwrap();
-                let cc = match last {
-                    crate::prompt::message::Block::Text {
-                        cache_control,
-                        ..
-                    } => cache_control.as_ref().unwrap(),
-                    _ => panic!("expected text block"),
-                };
-                assert_eq!(
-                    cc,
-                    &CacheControl::Ephemeral {
-                        ttl: Some(CacheTtl::OneHour)
-                    }
-                );
+        let last = cached.system.as_ref().unwrap().last().unwrap();
+        let cc = match last {
+            crate::prompt::message::Block::Text { cache_control, .. } => {
+                cache_control.as_ref().unwrap()
             }
-            _ => panic!("expected MultiPart after cache_1h()"),
-        }
+            _ => panic!("expected text block"),
+        };
+        assert_eq!(
+            cc,
+            &CacheControl::Ephemeral {
+                ttl: Some(CacheTtl::OneHour)
+            }
+        );
     }
 
     #[test]
@@ -738,7 +712,11 @@ mod tests {
             cached.cache();
         }
         assert_eq!(
-            cached.messages.iter().filter(|m| m.content.has_cache()).count(),
+            cached
+                .messages
+                .iter()
+                .filter(|m| m.content.has_cache())
+                .count(),
             7,
         );
 
@@ -833,7 +811,7 @@ mod tests {
 
     #[test]
     fn cache_windowed_1h_sets_one_hour_ttl_on_last_message() {
-        use crate::prompt::message::{Block, CacheControl, CacheTtl, Content};
+        use crate::prompt::message::{Block, CacheControl, CacheTtl};
 
         let prompt = Prompt::default();
         let mut cached = CachedPrompt::from(prompt);
@@ -844,12 +822,7 @@ mod tests {
 
         // The last message's last block should carry a 1-hour TTL.
         let last_msg = cached.messages.last().unwrap();
-        let last_block = match &last_msg.content {
-            Content::MultiPart(blocks) => blocks.last().unwrap(),
-            Content::SinglePart(_) => {
-                panic!("expected MultiPart after cache_windowed_1h")
-            }
-        };
+        let last_block = last_msg.content.last().unwrap();
         let cc = match last_block {
             Block::Text { cache_control, .. } => {
                 cache_control.as_ref().unwrap()
@@ -866,7 +839,7 @@ mod tests {
 
     #[test]
     fn cache_windowed_with_preserves_earlier_ttls() {
-        use crate::prompt::message::{Block, CacheControl, CacheTtl, Content};
+        use crate::prompt::message::{Block, CacheControl, CacheTtl};
 
         let prompt = Prompt::default();
         let mut cached = CachedPrompt::from(prompt);
@@ -896,10 +869,7 @@ mod tests {
         // round 2 keeps 5m, round 3 is now 1h.
         let ttl_at = |idx: usize| -> CacheControl {
             let msg = &cached.messages[idx];
-            let block = match &msg.content {
-                Content::MultiPart(blocks) => blocks.last().unwrap(),
-                Content::SinglePart(_) => panic!("expected MultiPart"),
-            };
+            let block = msg.content.last().unwrap();
             match block {
                 Block::Text { cache_control, .. } => {
                     cache_control.as_ref().unwrap().clone()

--- a/misanthropic/src/prompt/index.rs
+++ b/misanthropic/src/prompt/index.rs
@@ -1,0 +1,306 @@
+//! [`Index`] and related types for addressing a [`Method`] or [`Content`]
+//! [`Block`] inside a [`Prompt`].
+//!
+//! The motivating use is cache-breakpoint placement: [`Prompt::indices`] yields
+//! every addressable position in Anthropic's cache-prefix order (tools →
+//! system → messages), and [`Prompt::get_mut`] resolves one to a `&mut Block`
+//! (or `&mut Method`) so a [`CacheControl`] can be dropped on it.
+//!
+//! [`CacheControl`]: crate::prompt::message::CacheControl
+use super::{Prompt, message::Block, tool::Method};
+
+/// An index into a [`Prompt`]. Addresses either a [`Method`] in
+/// [`Prompt::tools`] or a [`Content`] [`Block`] in [`Prompt::system`] /
+/// [`Prompt::messages`].
+///
+/// The derived [`Ord`] matches Anthropic's cache-prefix order: every
+/// [`Method`] sorts before every [`Block`], system blocks before message
+/// blocks. [`Prompt::indices`] yields indices in this order.
+///
+/// [`Prompt::tools`]: Prompt::tools
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    PartialEq,
+    PartialOrd,
+    Eq,
+    Ord,
+    Hash,
+    derive_more::From,
+    derive_more::IsVariant,
+)]
+pub enum Index {
+    /// A [`Method`] in [`Prompt::tools`].
+    Method(MethodIndex),
+    /// A [`Content`] [`Block`] in [`Prompt::system`] or [`Prompt::messages`].
+    Block(BlockIndex),
+}
+
+/// Index of a [`Method`] in [`Prompt::tools`].
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    PartialEq,
+    PartialOrd,
+    Eq,
+    Ord,
+    Hash,
+    derive_more::Deref,
+    derive_more::From,
+    derive_more::Into,
+)]
+pub struct MethodIndex(pub usize);
+
+/// Index of a [`Content`] [`Block`] in a [`Prompt`].
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    PartialEq,
+    PartialOrd,
+    Eq,
+    Ord,
+    Hash,
+    derive_more::IsVariant,
+)]
+pub enum BlockIndex {
+    /// A [`Block`] in [`Prompt::system`].
+    System(usize),
+    /// A `(message, block)` pair in [`Prompt::messages`].
+    Message((usize, usize)),
+}
+
+/// A shared reference to a [`Method`] or a [`Content`] [`Block`] in a
+/// [`Prompt`], as returned by [`Prompt::get`].
+pub enum IndexRef<'a, 'p> {
+    /// Reference to a [`Method`] in [`Prompt::tools`].
+    Method(&'a Method<'p>),
+    /// Reference to a [`Content`] [`Block`] in a [`Prompt`].
+    Block(&'a Block<'p>),
+}
+
+/// A mutable reference to a [`Method`] or a [`Content`] [`Block`] in a
+/// [`Prompt`], as returned by [`Prompt::get_mut`].
+pub enum IndexMut<'a, 'p> {
+    /// Mutable reference to a [`Method`] in [`Prompt::tools`].
+    Method(&'a mut Method<'p>),
+    /// Mutable reference to a [`Content`] [`Block`] in a [`Prompt`].
+    Block(&'a mut Block<'p>),
+}
+
+#[cfg(feature = "markdown")]
+impl<'a> crate::markdown::ToMarkdown<'a> for IndexRef<'_, 'a> {
+    fn markdown_events_custom(
+        &'a self,
+        options: crate::markdown::Options,
+    ) -> Box<dyn Iterator<Item = pulldown_cmark::Event<'a>> + 'a> {
+        match self {
+            IndexRef::Method(method) => method.markdown_events_custom(options),
+            IndexRef::Block(block) => block.markdown_events_custom(options),
+        }
+    }
+}
+
+impl<'p> Prompt<'p> {
+    /// Resolve an [`Index`] to a shared reference, or [`None`] if it is out of
+    /// bounds (or addresses [`Prompt::system`] / [`Prompt::tools`] when absent).
+    pub fn get(&self, index: Index) -> Option<IndexRef<'_, 'p>> {
+        match index {
+            Index::Method(MethodIndex(i)) => {
+                self.functions.as_ref()?.get(i).map(IndexRef::Method)
+            }
+            Index::Block(BlockIndex::System(i)) => {
+                self.system.as_ref()?.get(i).map(IndexRef::Block)
+            }
+            Index::Block(BlockIndex::Message((m, b))) => {
+                self.messages.get(m)?.content.get(b).map(IndexRef::Block)
+            }
+        }
+    }
+
+    /// Resolve an [`Index`] to a mutable reference, or [`None`] if it is out of
+    /// bounds (or addresses [`Prompt::system`] / [`Prompt::tools`] when absent).
+    pub fn get_mut(&mut self, index: Index) -> Option<IndexMut<'_, 'p>> {
+        match index {
+            Index::Method(MethodIndex(i)) => {
+                self.functions.as_mut()?.get_mut(i).map(IndexMut::Method)
+            }
+            Index::Block(BlockIndex::System(i)) => {
+                self.system.as_mut()?.get_mut(i).map(IndexMut::Block)
+            }
+            Index::Block(BlockIndex::Message((m, b))) => self
+                .messages
+                .get_mut(m)?
+                .content
+                .get_mut(b)
+                .map(IndexMut::Block),
+        }
+    }
+
+    /// Iterate over every addressable [`Index`] in cache-prefix order:
+    /// tools, then system blocks, then message blocks.
+    pub fn indices(&self) -> impl Iterator<Item = Index> + '_ {
+        let tools = (0..self.functions.as_ref().map_or(0, Vec::len))
+            .map(|i| Index::Method(MethodIndex(i)));
+
+        let system = (0..self.system.as_ref().map_or(0, |c| c.len()))
+            .map(|i| Index::Block(BlockIndex::System(i)));
+
+        let messages = self.messages.iter().enumerate().flat_map(|(m, msg)| {
+            (0..msg.content.len())
+                .map(move |b| Index::Block(BlockIndex::Message((m, b))))
+        });
+
+        tools.chain(system).chain(messages)
+    }
+}
+
+impl<'p> std::ops::Index<MethodIndex> for Prompt<'p> {
+    type Output = Method<'p>;
+
+    /// # Panics
+    /// - If [`Prompt::tools`] is absent or the index is out of bounds.
+    fn index(&self, index: MethodIndex) -> &Self::Output {
+        &self.functions.as_ref().expect("no tools on this prompt")[index.0]
+    }
+}
+
+impl std::ops::IndexMut<MethodIndex> for Prompt<'_> {
+    /// # Panics
+    /// - If [`Prompt::tools`] is absent or the index is out of bounds.
+    fn index_mut(&mut self, index: MethodIndex) -> &mut Self::Output {
+        &mut self.functions.as_mut().expect("no tools on this prompt")[index.0]
+    }
+}
+
+impl<'p> std::ops::Index<BlockIndex> for Prompt<'p> {
+    type Output = Block<'p>;
+
+    /// # Panics
+    /// - If the addressed [`Block`] (or [`Prompt::system`]) does not exist.
+    fn index(&self, index: BlockIndex) -> &Self::Output {
+        match index {
+            BlockIndex::System(i) => {
+                &self.system.as_ref().expect("no system on this prompt")[i]
+            }
+            BlockIndex::Message((m, b)) => &self.messages[m].content[b],
+        }
+    }
+}
+
+impl std::ops::IndexMut<BlockIndex> for Prompt<'_> {
+    /// # Panics
+    /// - If the addressed [`Block`] (or [`Prompt::system`]) does not exist.
+    fn index_mut(&mut self, index: BlockIndex) -> &mut Self::Output {
+        match index {
+            BlockIndex::System(i) => {
+                &mut self.system.as_mut().expect("no system on this prompt")[i]
+            }
+            BlockIndex::Message((m, b)) => &mut self.messages[m].content[b],
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_index_ordering() {
+        assert!(
+            [
+                Index::Method(0.into()),
+                Index::Method(1.into()),
+                BlockIndex::System(0).into(),
+                BlockIndex::System(1).into(),
+                BlockIndex::Message((0, 0)).into(),
+                BlockIndex::Message((0, 1)).into(),
+                BlockIndex::Message((1, 0)).into()
+            ]
+            .is_sorted()
+        )
+    }
+
+    #[test]
+    fn test_block_index_ordering() {
+        assert!(
+            [
+                // tools go here in cache
+                BlockIndex::System(0),
+                BlockIndex::System(1),
+                BlockIndex::Message((0, 0)),
+                BlockIndex::Message((0, 1)),
+                BlockIndex::Message((1, 0))
+            ]
+            .is_sorted()
+        )
+    }
+
+    #[test]
+    fn indices_in_cache_prefix_order() {
+        use crate::prompt::message::{Content, Role};
+        use crate::tool::Method;
+
+        let prompt = Prompt::default()
+            .add_tool(Method {
+                name: "a".into(),
+                description: "a".into(),
+                schema: serde_json::json!({}),
+                cache_control: None,
+                strict: None,
+            })
+            .set_system(Content(vec!["sys0".into(), "sys1".into()]))
+            .add_message((Role::User, "hi"))
+            .unwrap();
+
+        let indices: Vec<_> = prompt.indices().collect();
+
+        // tools (1) → system blocks (2) → message blocks (1)
+        assert_eq!(
+            indices,
+            vec![
+                Index::Method(MethodIndex(0)),
+                Index::Block(BlockIndex::System(0)),
+                Index::Block(BlockIndex::System(1)),
+                Index::Block(BlockIndex::Message((0, 0))),
+            ]
+        );
+        // already sorted, matching the derived Ord
+        assert!(indices.is_sorted());
+    }
+
+    #[test]
+    fn get_and_get_mut_round_trip() {
+        use crate::prompt::message::{Block, Content, Role};
+
+        let mut prompt = Prompt::default()
+            .set_system(Content::text("system"))
+            .add_message((Role::User, "hello"))
+            .unwrap();
+
+        // get resolves a message block.
+        let idx = Index::Block(BlockIndex::Message((0, 0)));
+        assert!(matches!(prompt.get(idx), Some(IndexRef::Block(_))));
+
+        // out-of-bounds resolves to None.
+        assert!(
+            prompt
+                .get(Index::Block(BlockIndex::Message((9, 0))))
+                .is_none()
+        );
+        assert!(prompt.get(Index::Method(MethodIndex(0))).is_none());
+
+        // get_mut lets us drop a cache breakpoint.
+        if let Some(IndexMut::Block(block)) = prompt.get_mut(idx) {
+            block.cache();
+        } else {
+            panic!("expected a block");
+        }
+        assert!(prompt[BlockIndex::Message((0, 0))].is_cached());
+
+        // panicking Index trait also works.
+        assert!(matches!(prompt[BlockIndex::System(0)], Block::Text { .. }));
+    }
+}

--- a/misanthropic/src/prompt/message.rs
+++ b/misanthropic/src/prompt/message.rs
@@ -88,10 +88,7 @@ impl std::fmt::Display for Role {
 pub struct Message<'a> {
     /// Who is the message from.
     pub role: Role,
-    /// The [`Content`] of the message as [one] or [more] [`Block`]s.
-    ///
-    /// [one]: Content::SinglePart
-    /// [more]: Content::MultiPart
+    /// The [`Content`] of the message as a sequence of [`Block`]s.
     pub content: Content<'a>,
 }
 
@@ -121,15 +118,10 @@ impl Message<'_> {
     /// Returns Some([`tool::Result`]) if the first [`Content`] [`Block`] is a
     /// [`Block::ToolResult`].
     pub fn tool_result(&self) -> Option<&crate::tool::Result<'_>> {
-        match &self.content {
-            Content::SinglePart(_) => None,
-            Content::MultiPart(parts) => {
-                if let Some(Block::ToolResult { result }) = parts.first() {
-                    Some(result)
-                } else {
-                    None
-                }
-            }
+        if let Some(Block::ToolResult { result }) = self.content.first() {
+            Some(result)
+        } else {
+            None
         }
     }
 
@@ -158,11 +150,9 @@ impl Message<'_> {
             return Some(self);
         }
 
-        if let Content::MultiPart(parts) = &mut self.content {
-            if let Some(Block::Thought { signature, .. }) = parts.last() {
-                if signature.is_empty() {
-                    parts.pop();
-                }
+        if let Some(Block::Thought { signature, .. }) = self.content.last() {
+            if signature.is_empty() {
+                self.content.pop();
             }
         }
 
@@ -217,14 +207,7 @@ impl<'a> IntoIterator for Message<'a> {
     type IntoIter = std::vec::IntoIter<Block<'a>>;
 
     fn into_iter(self) -> Self::IntoIter {
-        match self.content {
-            Content::SinglePart(text) => vec![Block::Text {
-                text,
-                cache_control: None,
-            }]
-            .into_iter(),
-            Content::MultiPart(parts) => parts.into_iter(),
-        }
+        self.content.into_iter()
     }
 }
 
@@ -495,14 +478,7 @@ impl<'a> IntoIterator for UserMessage<'a> {
     type IntoIter = std::vec::IntoIter<Block<'a>>;
 
     fn into_iter(self) -> Self::IntoIter {
-        match self.inner.content {
-            Content::SinglePart(text) => vec![Block::Text {
-                text,
-                cache_control: None,
-            }]
-            .into_iter(),
-            Content::MultiPart(parts) => parts.into_iter(),
-        }
+        self.inner.content.into_iter()
     }
 }
 
@@ -575,107 +551,69 @@ impl From<NotTheUser> for Cow<'static, str> {
     }
 }
 
-/// Content of a [`Message`].
+/// Content of a [`Message`], stored as a sequence of [`Block`]s.
+///
+/// [`Content`] derefs to `Vec<Block>`, so the usual slice/`Vec` accessors
+/// (`get`, `get_mut`, `iter`, `iter_mut`, `len`, indexing, ...) are available
+/// directly. On the wire it always serializes as an array of blocks; a bare
+/// JSON string is still accepted when deserializing and becomes a single
+/// [`Block::Text`].
 #[derive(
-    Clone, Debug, Serialize, Deserialize, Hash, derive_more::IsVariant,
+    Clone, Debug, Hash, Serialize, derive_more::Deref, derive_more::DerefMut,
 )]
-#[serde(rename_all = "snake_case")]
-#[serde(untagged)]
+#[serde(transparent)]
 #[cfg_attr(any(feature = "partial-eq", test), derive(PartialEq))]
-pub enum Content<'a> {
-    /// Single part text-only content.
-    SinglePart(crate::CowStr<'a>),
-    /// Multiple content [`Block`]s.
-    MultiPart(Vec<Block<'a>>),
+pub struct Content<'a>(pub Vec<Block<'a>>);
+
+impl<'de, 'a> Deserialize<'de> for Content<'a> {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        // Mirror the API's "content may be a bare string or an array of blocks"
+        // wire form with the untagged derive, then normalize to blocks. A
+        // hand-written visitor would be more code and harder to reason about.
+        #[derive(Deserialize)]
+        #[serde(untagged)]
+        enum Wire<'a> {
+            Text(crate::CowStr<'a>),
+            Blocks(Vec<Block<'a>>),
+        }
+
+        Ok(Content(match Wire::deserialize(deserializer)? {
+            Wire::Text(text) => vec![Block::Text {
+                text,
+                cache_control: None,
+            }],
+            Wire::Blocks(blocks) => blocks,
+        }))
+    }
 }
 
 impl<'a> Content<'a> {
-    /// Const constructor for static text content. Not available with the
-    /// `langsan` feature.
-    #[cfg(not(feature = "langsan"))]
-    pub const fn const_text(text: &'static str) -> Self {
-        Self::SinglePart(std::borrow::Cow::Borrowed(text))
-    }
-
-    /// Text content.
+    /// Text content as a single [`Block::Text`].
     pub fn text<T>(text: T) -> Self
     where
         T: Into<crate::CowStr<'a>>,
     {
-        Self::SinglePart(text.into())
+        Self(vec![Block::text(text)])
     }
 
-    /// Returns the number of [`Block`]s in self.
-    pub fn len(&self) -> usize {
-        match self {
-            Self::SinglePart(_) => 1,
-            Self::MultiPart(parts) => parts.len(),
-        }
-    }
-
-    /// Returns true if `self` is empty.
-    pub fn is_empty(&self) -> bool {
-        self.len() == 0
-    }
-
-    /// Unwrap [`Content::SinglePart`] as a [`Block::Text`]. This will panic if
-    /// `self` is [`MultiPart`].
-    ///
-    /// [`SinglePart`]: Content::SinglePart
-    /// [`MultiPart`]: Content::MultiPart
-    ///
-    /// # Panics
-    /// - If the content is [`MultiPart`].
-    pub fn unwrap_single_part(self) -> Block<'a> {
-        match self {
-            Self::SinglePart(text) => Block::Text {
-                text,
-                cache_control: None,
-            },
-            Self::MultiPart(_) => {
-                panic!("Content is MultiPart, not SinglePart");
-            }
-        }
-    }
-
-    /// Add a [`Block`] to the [`Content`]. If the [`Content`] is a
-    /// [`SinglePart`], it will be converted to a [`MultiPart`].
-    ///
-    /// The index of the inserted block is returned.
-    ///
-    /// [`SinglePart`]: Content::SinglePart
-    /// [`MultiPart`]: Content::MultiPart
+    /// Add a [`Block`] to the [`Content`], returning the index of the inserted
+    /// block.
     pub fn push<P>(&mut self, part: P) -> usize
     where
         P: Into<Block<'a>>,
     {
-        // If there is a SinglePart message, convert it to a MultiPart message.
-        if self.is_single_part() {
-            // the old switcheroo
-            let mut old = Content::MultiPart(vec![]);
-            std::mem::swap(self, &mut old);
-            // This can never loop because we ensure self is a MultiPart which
-            // will skip this block.
-            self.push(old.unwrap_single_part());
-        }
-
-        if let Content::MultiPart(parts) = self {
-            let index = parts.len();
-            parts.push(part.into());
-            return index;
-        } else {
-            unreachable!()
-        }
+        let index = self.0.len();
+        self.0.push(part.into());
+        index
     }
 
-    /// Add a cache breakpoint to the final [`Block`]. If the [`Content`] is
-    /// [`SinglePart`], it will be converted to [`MultiPart`] first.
+    /// Add a cache breakpoint to the final [`Block`].
     ///
     /// Uses the default 5-minute ephemeral TTL. For a 1-hour TTL, use
     /// [`cache_1h`](Content::cache_1h).
-    ///
-    /// [`SinglePart`]: Content::SinglePart
-    /// [`MultiPart`]: Content::MultiPart
     pub fn cache(&mut self) {
         self.cache_with(CacheControl::ephemeral());
     }
@@ -688,54 +626,24 @@ impl<'a> Content<'a> {
         self.cache_with(CacheControl::one_hour());
     }
 
-    /// Add a cache breakpoint with a caller-provided [`CacheControl`] to
-    /// the final [`Block`]. If the [`Content`] is [`SinglePart`], it will
-    /// be converted to [`MultiPart`] first.
-    ///
-    /// [`SinglePart`]: Content::SinglePart
-    /// [`MultiPart`]: Content::MultiPart
+    /// Add a cache breakpoint with a caller-provided [`CacheControl`] to the
+    /// final [`Block`]. Does nothing if the content is empty.
     pub fn cache_with(&mut self, cache_control: CacheControl) {
-        if self.is_single_part() {
-            let mut old = Content::MultiPart(vec![]);
-            std::mem::swap(self, &mut old);
-            self.push(old.unwrap_single_part());
-        }
-
-        if let Content::MultiPart(parts) = self
-            && let Some(block) = parts.last_mut()
-        {
+        if let Some(block) = self.0.last_mut() {
             block.cache_with(cache_control);
         }
     }
 
     /// Remove all cache breakpoints from all blocks in this content.
     pub fn uncache(&mut self) {
-        if let Content::MultiPart(parts) = self {
-            for block in parts {
-                block.uncache();
-            }
+        for block in &mut self.0 {
+            block.uncache();
         }
-        // SinglePart has no cache_control — nothing to do.
     }
 
     /// Returns `true` if any block in this content has a cache breakpoint.
     pub fn has_cache(&self) -> bool {
-        match self {
-            Content::MultiPart(parts) => parts.iter().any(|b| b.is_cached()),
-            Content::SinglePart(_) => false,
-        }
-    }
-
-    /// Get the last [`Block`] in the [`Content`]. Returns [`None`] if the
-    /// [`Content`] is empty or [`SinglePart`].
-    ///
-    /// [`SinglePart`]: Content::SinglePart
-    // Because to make it multi-part on access this would have to be &mut
-    pub fn last(&self) -> Option<&Block<'_>> {
-        match self {
-            Self::SinglePart(_) => None,
-            Self::MultiPart(parts) => parts.last(),
-        }
+        self.0.iter().any(|b| b.is_cached())
     }
 
     /// Convert to a `'static` lifetime by taking ownership of the [`Cow`]
@@ -743,27 +651,11 @@ impl<'a> Content<'a> {
     ///
     /// [`Cow`]: std::borrow::Cow
     pub fn into_static(self) -> Content<'static> {
-        match self {
-            Self::SinglePart(text) => {
-                #[cfg(not(feature = "langsan"))]
-                {
-                    Content::SinglePart(std::borrow::Cow::Owned(
-                        text.into_owned(),
-                    ))
-                }
-                #[cfg(feature = "langsan")]
-                {
-                    Content::SinglePart(text.into_static())
-                }
-            }
-            Self::MultiPart(parts) => Content::MultiPart(
-                parts.into_iter().map(Block::into_static).collect(),
-            ),
-        }
+        Content(self.0.into_iter().map(Block::into_static).collect())
     }
 
-    /// Push a [`Delta`] into the [`Content`]. The types must be compatible or
-    /// this will return a [`ContentMismatch`] error.
+    /// Push a [`Delta`] into the final [`Block`]. The types must be compatible
+    /// or this will return a [`ContentMismatch`] error.
     ///
     /// It is an error to try to merge a single json delta into a content block.
     pub fn push_delta(
@@ -783,75 +675,17 @@ impl<'a> Content<'a> {
             });
         }
 
-        match self {
-            Self::SinglePart(_) => {
-                let mut old = Content::MultiPart(vec![]);
-                std::mem::swap(self, &mut old);
-                self.push(old.unwrap_single_part());
-                self.push_delta(delta)?;
-            }
-            Self::MultiPart(parts) => {
-                parts
-                    .last_mut()
-                    .unwrap()
-                    .merge_deltas(std::iter::once(delta))?;
-            }
-        }
+        self.0
+            .last_mut()
+            .unwrap()
+            .merge_deltas(std::iter::once(delta))?;
 
         Ok(())
     }
 
     /// Drains the blocks from the content.
     pub fn drain(&'a mut self) -> impl Iterator<Item = Block<'a>> + 'a {
-        let ret: Box<dyn Iterator<Item = Block<'a>>> = match self {
-            Self::SinglePart(_) => {
-                let mut old = Content::MultiPart(vec![]);
-                std::mem::swap(self, &mut old);
-                match old {
-                    Content::SinglePart(text) => {
-                        Box::new(std::iter::once(Block::Text {
-                            text,
-                            cache_control: None,
-                        }))
-                    }
-                    Content::MultiPart(parts) => Box::new(parts.into_iter()),
-                }
-            }
-            Self::MultiPart(parts) => Box::new(parts.drain(..)),
-        };
-
-        ret
-    }
-
-    /// Get a block mutably. If this is [`SinglePart`] content, it will be
-    /// converted to [`MultiPart`] first.
-    pub fn get_mut(&mut self, index: usize) -> Option<&mut Block<'a>> {
-        if self.is_single_part() {
-            let mut old = Content::MultiPart(vec![]);
-            std::mem::swap(self, &mut old);
-            self.push(old.unwrap_single_part());
-        }
-        // Self is now MultiPart
-
-        match self {
-            Self::MultiPart(parts) => parts.get_mut(index),
-            Self::SinglePart(_) => unreachable!(),
-        }
-    }
-
-    /// Iterate mutably over the blocks. If this is [`SinglePart`] content, it
-    /// will be converted to [`MultiPart`] first.
-    pub fn iter_mut(&mut self) -> impl Iterator<Item = &mut Block<'a>> {
-        if self.is_single_part() {
-            let mut old = Content::MultiPart(vec![]);
-            std::mem::swap(self, &mut old);
-            self.push(old.unwrap_single_part());
-        }
-
-        match self {
-            Self::MultiPart(parts) => parts.iter_mut(),
-            Self::SinglePart(_) => unreachable!(),
-        }
+        self.0.drain(..)
     }
 }
 
@@ -860,14 +694,7 @@ impl<'a> IntoIterator for Content<'a> {
     type IntoIter = std::vec::IntoIter<Block<'a>>;
 
     fn into_iter(self) -> Self::IntoIter {
-        match self {
-            Content::SinglePart(text) => vec![Block::Text {
-                text,
-                cache_control: None,
-            }]
-            .into_iter(),
-            Content::MultiPart(parts) => parts.into_iter(),
-        }
+        self.0.into_iter()
     }
 }
 
@@ -884,16 +711,11 @@ impl<'a> crate::markdown::ToMarkdown<'a> for Content<'a> {
     ) -> Box<dyn Iterator<Item = pulldown_cmark::Event<'a>> + 'a> {
         use pulldown_cmark::Event;
 
-        let it: Box<dyn Iterator<Item = Event<'a>> + 'a> = match self {
-            Self::SinglePart(string) => {
-                Box::new(pulldown_cmark::Parser::new(string))
-            }
-            Self::MultiPart(parts) => Box::new(
-                parts
-                    .iter()
-                    .flat_map(move |part| part.markdown_events_custom(options)),
-            ),
-        };
+        let it: Box<dyn Iterator<Item = Event<'a>> + 'a> = Box::new(
+            self.0
+                .iter()
+                .flat_map(move |part| part.markdown_events_custom(options)),
+        );
 
         it
     }
@@ -902,21 +724,16 @@ impl<'a> crate::markdown::ToMarkdown<'a> for Content<'a> {
 #[cfg(not(feature = "markdown"))]
 impl std::fmt::Display for Content<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::SinglePart(string) => write!(f, "{}", string),
-            // This could be derived but the `Join` trait is not stable. Neither
-            // is `Iterator::intersperse`. This also has fewer allocations.
-            Self::MultiPart(parts) => {
-                let mut iter = parts.iter();
-                if let Some(part) = iter.next() {
-                    write!(f, "{}", part)?;
-                    for part in iter {
-                        write!(f, "{}{}", Self::SEP, part)?;
-                    }
-                }
-                Ok(())
+        // This could be derived but the `Join` trait is not stable. Neither is
+        // `Iterator::intersperse`. This also has fewer allocations.
+        let mut iter = self.0.iter();
+        if let Some(part) = iter.next() {
+            write!(f, "{}", part)?;
+            for part in iter {
+                write!(f, "{}{}", Self::SEP, part)?;
             }
         }
+        Ok(())
     }
 }
 
@@ -947,7 +764,7 @@ where
     T: Into<Block<'a>>,
 {
     fn from(block: T) -> Self {
-        Self::MultiPart(vec![block.into()])
+        Self(vec![block.into()])
     }
 }
 
@@ -956,7 +773,7 @@ where
     T: Into<Block<'a>>,
 {
     fn from_iter<I: IntoIterator<Item = T>>(iter: I) -> Self {
-        Self::MultiPart(iter.into_iter().map(Into::into).collect())
+        Self(iter.into_iter().map(Into::into).collect())
     }
 }
 
@@ -965,27 +782,7 @@ where
     T: Into<Block<'a>>,
 {
     fn extend<I: IntoIterator<Item = T>>(&mut self, iter: I) {
-        let text = match self {
-            Self::SinglePart(old) => {
-                let mut text: crate::CowStr<'a> = String::new().into();
-                std::mem::swap(old, &mut text);
-                text
-            }
-            Self::MultiPart(parts) => {
-                parts.extend(iter.into_iter().map(Into::into));
-                return;
-            }
-        };
-        // We have single-part content, so we need to convert it to multi-part
-        // and then extend it.
-
-        *self = Self::MultiPart(vec![Block::Text {
-            text,
-            cache_control: None,
-        }]);
-        // This can never recurse infinitely because we just converted to
-        // MultiPart and that will skip this by returning early.
-        self.extend(iter);
+        self.0.extend(iter.into_iter().map(Into::into));
     }
 }
 
@@ -1001,13 +798,13 @@ where
     T: Into<Block<'a>>,
 {
     fn from(blocks: [T; N]) -> Self {
-        Self::MultiPart(blocks.into_iter().map(|t| t.into()).collect())
+        Self(blocks.into_iter().map(|t| t.into()).collect())
     }
 }
 
 impl<'a> From<&'a [&'a str]> for Content<'a> {
     fn from(text: &'a [&'a str]) -> Self {
-        Self::MultiPart(text.iter().map(|t| (*t).into()).collect())
+        Self(text.iter().map(|t| (*t).into()).collect())
     }
 }
 
@@ -1016,7 +813,7 @@ where
     T: Into<Block<'a>>,
 {
     fn from(blocks: Vec<T>) -> Self {
-        Self::MultiPart(blocks.into_iter().map(Into::into).collect())
+        Self(blocks.into_iter().map(Into::into).collect())
     }
 }
 
@@ -1638,9 +1435,7 @@ impl CacheControl {
     }
 }
 
-/// Image content for [`MultiPart`] [`Message`]s.
-///
-/// [`MultiPart`]: Content::MultiPart
+/// Image content [`Block`] of a [`Message`].
 #[derive(Clone, Debug, Serialize, Deserialize, derive_more::Display, Hash)]
 #[cfg_attr(any(feature = "partial-eq", test), derive(PartialEq))]
 #[serde(rename_all = "snake_case")]
@@ -1855,8 +1650,6 @@ impl TryFrom<image::ImageFormat> for MediaType {
 
 #[cfg(test)]
 mod tests {
-    use std::vec;
-
     #[cfg(feature = "markdown")]
     use crate::markdown::ToMarkdown;
 
@@ -1918,7 +1711,7 @@ mod tests {
         assert!(!message.is_empty());
         let message: Message = Message {
             role: Role::User,
-            content: Content::MultiPart(vec![]),
+            content: Content(vec![]),
         };
         assert!(message.is_empty());
     }
@@ -1944,7 +1737,7 @@ mod tests {
         let content: Content<'static> = content.into_static();
         assert_eq!(content.to_string(), "Hello, world!");
 
-        let content = Content::SinglePart("Hello, world!".into());
+        let content = Content::text("Hello, world!");
         let content: Content<'static> = content.into_static();
         assert_eq!(content.to_string(), "Hello, world!");
 
@@ -2053,10 +1846,10 @@ mod tests {
     fn test_message_len() {
         let mut message = Message {
             role: Role::User,
-            content: Content::SinglePart("Hello, world!".into()),
+            content: Content::text("Hello, world!"),
         };
 
-        assert_eq!(message.len(), 1); // single part
+        assert_eq!(message.len(), 1); // one text block
 
         message.content.push("How are you?");
 
@@ -2101,24 +1894,11 @@ mod tests {
 
     #[test]
     fn test_content_is_empty() {
-        let mut content = Content::SinglePart("Hello, world!".into());
+        let mut content = Content::text("Hello, world!");
         assert!(!content.is_empty());
 
-        content = Content::MultiPart(vec![]);
+        content = Content(vec![]);
         assert!(content.is_empty());
-    }
-
-    #[test]
-    fn tests_content_unwrap_single_part() {
-        let content = Content::SinglePart("Hello, world!".into());
-        assert_eq!(content.unwrap_single_part().to_string(), "Hello, world!");
-    }
-
-    #[test]
-    #[should_panic]
-    fn test_content_unwrap_single_part_panics() {
-        let content = Content::MultiPart(vec![]);
-        content.unwrap_single_part();
     }
 
     #[test]
@@ -2177,10 +1957,10 @@ mod tests {
     fn test_message_markdown() {
         use crate::markdown::ToMarkdown;
 
-        // test user heading, single part
+        // test user heading, single block
         let message = Message {
             role: Role::User,
-            content: Content::SinglePart("Hello, world!".into()),
+            content: Content::text("Hello, world!"),
         };
 
         let opts = crate::markdown::Options::default()
@@ -2192,10 +1972,10 @@ mod tests {
             "### User\n\nHello, world!"
         );
 
-        // test assistant heading, multi part
+        // test assistant heading, multiple blocks
         let message = Message {
             role: Role::Assistant,
-            content: Content::MultiPart(vec![
+            content: Content(vec![
                 "Hello, world!".into(),
                 "How are you?".into(),
             ]),
@@ -2209,7 +1989,7 @@ mod tests {
         // Test tool result (success)
         let message: Message = tool::Result {
             tool_use_id: "tool_123".into(),
-            content: Content::SinglePart("Hello, world!".into()),
+            content: Content::text("Hello, world!"),
             is_error: false,
             cache_control: None,
         }
@@ -2217,13 +1997,13 @@ mod tests {
 
         assert_eq!(
             message.markdown_custom(opts).to_string(),
-            "### Tool\n\n````json\n{\"type\":\"tool_result\",\"tool_use_id\":\"tool_123\",\"content\":\"Hello, world!\",\"is_error\":false}\n````"
+            "### Tool\n\n````json\n{\"type\":\"tool_result\",\"tool_use_id\":\"tool_123\",\"content\":[{\"type\":\"text\",\"text\":\"Hello, world!\"}],\"is_error\":false}\n````"
         );
 
         // Test tool result (error)
         let message: Message = tool::Result {
             tool_use_id: "tool_123".into(),
-            content: Content::SinglePart("Hello, world!".into()),
+            content: Content::text("Hello, world!"),
             is_error: true,
             cache_control: None,
         }
@@ -2231,7 +2011,7 @@ mod tests {
 
         assert_eq!(
             message.markdown_custom(opts).to_string(),
-            "### Error\n\n````json\n{\"type\":\"tool_result\",\"tool_use_id\":\"tool_123\",\"content\":\"Hello, world!\",\"is_error\":true}\n````"
+            "### Error\n\n````json\n{\"type\":\"tool_result\",\"tool_use_id\":\"tool_123\",\"content\":[{\"type\":\"text\",\"text\":\"Hello, world!\"}],\"is_error\":true}\n````"
         );
     }
 
@@ -2354,9 +2134,7 @@ mod tests {
     fn test_user_message_from_iter() {
         // From an iterator of &str (via blanket Into<Block>).
         let msg: UserMessage = ["Hello,", "world!"].into_iter().collect();
-        let Content::MultiPart(blocks) = msg.content() else {
-            panic!("expected MultiPart");
-        };
+        let blocks = msg.content();
         assert_eq!(blocks.len(), 2);
 
         // From an iterator of tool::Result.
@@ -2375,9 +2153,7 @@ mod tests {
             },
         ];
         let msg: UserMessage = results.into_iter().collect();
-        let Content::MultiPart(blocks) = msg.content() else {
-            panic!("expected MultiPart");
-        };
+        let blocks = msg.content();
         assert_eq!(blocks.len(), 2);
         assert!(matches!(blocks[0], Block::ToolResult { .. }));
         assert!(matches!(blocks[1], Block::ToolResult { .. }));
@@ -2387,9 +2163,7 @@ mod tests {
     fn test_assistant_message_from_iter() {
         let msg: AssistantMessage =
             ["thinking...", "done."].into_iter().collect();
-        let Content::MultiPart(blocks) = msg.content() else {
-            panic!("expected MultiPart");
-        };
+        let blocks = msg.content();
         assert_eq!(blocks.len(), 2);
     }
 

--- a/misanthropic/src/response/message.rs
+++ b/misanthropic/src/response/message.rs
@@ -104,7 +104,7 @@ impl Message<'_> {
     where
         T: serde::de::DeserializeOwned,
     {
-        use crate::prompt::message::{Block, Content};
+        use crate::prompt::message::Block;
 
         match self.stop_reason {
             Some(StopReason::Refusal) => return Err(JsonError::Refusal),
@@ -112,16 +112,15 @@ impl Message<'_> {
             _ => {}
         }
 
-        let text: &str = match &self.inner.content {
-            Content::SinglePart(text) => text.as_ref(),
-            Content::MultiPart(blocks) => blocks
-                .iter()
-                .find_map(|b| match b {
-                    Block::Text { text, .. } => Some(text.as_ref()),
-                    _ => None,
-                })
-                .ok_or(JsonError::NoTextBlock)?,
-        };
+        let text: &str = self
+            .inner
+            .content
+            .iter()
+            .find_map(|b| match b {
+                Block::Text { text, .. } => Some(text.as_ref()),
+                _ => None,
+            })
+            .ok_or(JsonError::NoTextBlock)?;
 
         Ok(serde_json::from_str(text)?)
     }
@@ -352,8 +351,8 @@ mod tests {
     fn json_parses_single_part_text() {
         let message = message_with(
             Some(StopReason::EndTurn),
-            prompt::message::Content::SinglePart(
-                r#"{"post_id":"abc","support":true}"#.into(),
+            prompt::message::Content::text(
+                r#"{"post_id":"abc","support":true}"#,
             ),
         );
         let parsed: VoteIntent = message.json().unwrap();
@@ -369,7 +368,7 @@ mod tests {
     #[test]
     fn json_skips_leading_thought_blocks() {
         use prompt::message::{Block, Content};
-        let content = Content::MultiPart(vec![
+        let content = Content(vec![
             Block::Thought {
                 thought: "Let me think about this...".into(),
                 signature: "sig".into(),
@@ -394,9 +393,7 @@ mod tests {
     fn json_returns_refusal_on_refusal_stop() {
         let message = message_with(
             Some(StopReason::Refusal),
-            prompt::message::Content::SinglePart(
-                "I can't help with that.".into(),
-            ),
+            prompt::message::Content::text("I can't help with that."),
         );
         let err = message.json::<VoteIntent>().unwrap_err();
         assert!(matches!(err, JsonError::Refusal));
@@ -406,7 +403,7 @@ mod tests {
     fn json_returns_tool_use_on_tool_stop() {
         let message = message_with(
             Some(StopReason::ToolUse),
-            prompt::message::Content::SinglePart("".into()),
+            prompt::message::Content::text(""),
         );
         let err = message.json::<VoteIntent>().unwrap_err();
         assert!(matches!(err, JsonError::ToolUse));
@@ -415,7 +412,7 @@ mod tests {
     #[test]
     fn json_returns_no_text_block_when_only_tool_blocks() {
         use prompt::message::{Block, Content};
-        let content = Content::MultiPart(vec![Block::ToolUse {
+        let content = Content(vec![Block::ToolUse {
             call: crate::tool::Use {
                 id: "u".into(),
                 name: "x".into(),
@@ -434,7 +431,7 @@ mod tests {
     fn json_propagates_serde_errors() {
         let message = message_with(
             Some(StopReason::EndTurn),
-            prompt::message::Content::SinglePart("not json".into()),
+            prompt::message::Content::text("not json"),
         );
         let err = message.json::<VoteIntent>().unwrap_err();
         assert!(matches!(err, JsonError::Json(_)));
@@ -450,8 +447,8 @@ mod tests {
             inner: prompt::AssistantMessage {
                 inner: prompt::Message {
                     role: prompt::message::Role::User,
-                    content: prompt::message::Content::SinglePart(
-                        "Hello, **world**!".into(),
+                    content: prompt::message::Content::text(
+                        "Hello, **world**!",
                     ),
                 },
             },

--- a/misanthropic/src/stream.rs
+++ b/misanthropic/src/stream.rs
@@ -33,10 +33,6 @@ pub enum Event {
     /// [`Content`] [`Block`] with empty content.
     ContentBlockStart {
         /// Index of the [`Content`] [`Block`] in [`prompt::message::Content`].
-        // TODO: Indexing. Issue is the Content::SinglePart is a String and
-        // Content::MultiPart is a Vec of Block. This is for serialization
-        // purposes. We should probably just use a Vec for both and write a
-        // custom serializer for that field.
         index: usize,
         /// Empty content block.
         content_block: Block<'static>,
@@ -1127,7 +1123,7 @@ pub(crate) mod tests {
             // message. `handle_stream_event` checks turn order.
             .add_message(Message {
                 role: Role::User,
-                content: Content::SinglePart("dummy message".into()),
+                content: Content::text("dummy message"),
             })
             .unwrap();
 
@@ -1141,7 +1137,7 @@ pub(crate) mod tests {
             last,
             prompt::Message {
                 role: Role::Assistant,
-                content: Content::MultiPart(vec![
+                content: Content(vec![
                     Block::Thought {
                         thought: "Let me solve this step by step:\n\n1. First break down 27 * 453\n2. 453 = 400 + 50 + 3".to_string().into(),
                         signature: "EqQBCgIYAhIM1gbcDa9GJwZA2b3hGgxBdjrkzLoky3dl1pkiMOYds...".to_string().into()
@@ -1166,7 +1162,7 @@ pub(crate) mod tests {
             // message. `handle_stream_event` checks turn order.
             .add_message(Message {
                 role: Role::User,
-                content: Content::SinglePart("dummy message".into()),
+                content: Content::text("dummy message"),
             })
             .unwrap();
 
@@ -1183,7 +1179,7 @@ pub(crate) mod tests {
             last,
             prompt::Message {
                 role: Role::Assistant,
-                content: Content::MultiPart(vec![
+                content: Content(vec![
                     Block::Thought {
                         thought: "Let me solve this step by step:\n\n1. First break down 27 * 453\n2. 453 = 400 + 50 + 3".to_string().into(),
                         signature: "EqQBCgIYAhIM1gbcDa9GJwZA2b3hGgxBdjrkzLoky3dl1pkiMOYds...".to_string().into()

--- a/misanthropic/src/tool.rs
+++ b/misanthropic/src/tool.rs
@@ -167,6 +167,39 @@ pub struct Method<'a> {
     pub strict: Option<bool>,
 }
 
+#[cfg(feature = "markdown")]
+impl<'a> crate::markdown::ToMarkdown<'a> for Method<'a> {
+    fn markdown_events_custom(
+        &'a self,
+        options: crate::markdown::Options,
+    ) -> Box<dyn Iterator<Item = pulldown_cmark::Event<'a>> + 'a> {
+        use pulldown_cmark::{CodeBlockKind, Event, Tag, TagEnd};
+
+        // Can't panic because derived Serialize
+        let mut payload = serde_json::to_value(self).unwrap();
+        // Can't panic because we know it's an object
+        payload.as_object_mut().unwrap().remove("cache_control");
+        payload.as_object_mut().unwrap().remove("strict");
+
+        if options.tool_use {
+            Box::new(
+                [
+                    Event::Start(Tag::CodeBlock(CodeBlockKind::Fenced(
+                        "json".into(),
+                    ))),
+                    Event::Text(
+                        serde_json::to_string_pretty(&payload).unwrap().into(),
+                    ),
+                    Event::End(TagEnd::CodeBlock),
+                ]
+                .into_iter(),
+            )
+        } else {
+            Box::new(std::iter::empty())
+        }
+    }
+}
+
 impl<'a> TryFrom<MethodBuilder<'a>> for Method<'a> {
     type Error = ToolBuildError;
 


### PR DESCRIPTION
Removes the `Content::SinglePart | MultiPart` wart and builds the `prompt::index` addressing API on top of it. One of the 1.0 blockers.

## Commit 1 — Content newtype
`Content` is now `struct Content(pub Vec<Block>)` deriving `Deref`/`DerefMut` to the inner `Vec`, replacing the untagged enum. This kills the `mem::swap`/`unwrap_single_part` promotion dance that made `get_mut`/`iter_mut`/`push` mutate `self` on read — a recurring source of cache-breakpoint bugs and the blocker for a clean indexing API.

- Bare-string wire form is accepted on **deserialize only** (small custom impl reusing the untagged-derive pattern); serialize **always emits a block array**. This is a deliberate, externally-observable wire change for plain-text content.
- Single-text content now compares equal to a single text block (fixes a latent `PartialEq` footgun).
- `Content::const_text` removed (can't build a `Vec` in `const`); `Block::const_text` stays.
- Swept ~75 call sites across `openai`, `dioxus`, `cot`, `response`, `stream`, `cached`, examples, and the frontend. Dioxus user-speech gating preserved.

## Commit 2 — prompt::index
- `Index` addresses a `Method` (tools) or a `Content` `Block` (system/messages). Its derived `Ord` **is** Anthropic's cache-prefix order (tools → system → messages).
- `Prompt::indices()` enumerates positions in that order — the entry point for cache-breakpoint placement.
- `Prompt::get`/`get_mut` return fallible `IndexRef`/`IndexMut`; `std::ops::Index`/`IndexMut` on `MethodIndex`/`BlockIndex` give panicking `prompt[idx]`.
- `IndexRef` renders as markdown, delegating to a new `Method: ToMarkdown` impl and `Block`. The `MethodRef`/`BlockRef` wrappers are gone — `&Method`/`&Block` inline.

## Commit 3
Frontend: `Method` missing `strict` field.

## Verification
Green on default (209), `--no-default-features` (179), `markdown` (222), and a broad valid feature set (265). `cargo fmt --check` clean. Not gated on `--all-features` (memory-palace needs Postgres) or the pre-existing clippy baseline (~29 errors on `dev`, unchanged by this branch).

## Not addressed (separate)
ToolBox `::`-separated tool names now fail Anthropic's tightened name regex (`^[a-zA-Z0-9_-]{1,128}$`). Pre-existing, unrelated to this change, fails safely at request time. Tracked for a later fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)