### PR TITLE
tool: use __ instead of :: in namespaced method names

### DIFF
--- a/misanthropic/src/tool/notepad.rs
+++ b/misanthropic/src/tool/notepad.rs
@@ -39,7 +39,7 @@ impl<'a> Tool for Notepad<'a> {
 
     fn methods(&self) -> Box<dyn Iterator<Item = Method<'static>> + '_> {
         Box::new(std::iter::once(
-            Method::builder("Notepad::push")
+            Method::builder("Notepad__push")
                 .description("Take a note for the next chat.")
                 .schema(json!({
                     "type": "object",
@@ -59,13 +59,13 @@ impl<'a> Tool for Notepad<'a> {
     async fn call<'c>(&mut self, call: Use<'c>) -> super::Result<'c> {
         #[cfg(feature = "log")]
         log::debug!("Notepad call: {:?}", serde_json::to_string_pretty(&call));
-        if !call.name.ends_with("Notepad::push") {
+        if !call.name.ends_with("Notepad__push") {
             #[cfg(feature = "log")]
             log::error!("Invalid tool name.");
             return super::Result {
                 tool_use_id: call.id,
                 content:
-                    "`Notepad::push` is the only method available on `Notepad`"
+                    "`Notepad__push` is the only method available on `Notepad`"
                         .into(),
                 is_error: true,
                 cache_control: None,
@@ -287,7 +287,7 @@ mod tests {
         let notepad = Notepad::new();
         let function = notepad.methods().next().unwrap();
         assert!(function.name.starts_with(stringify!(Notepad)));
-        assert!(function.name.ends_with("::push"));
+        assert!(function.name.ends_with("__push"));
         assert_eq!(
             function.description,
             Cow::Borrowed("Take a note for the next chat.")
@@ -312,7 +312,7 @@ mod tests {
         let mut notepad = Notepad::new();
         let call = Use {
             id: "abcd".into(),
-            name: "Notepad::push".into(),
+            name: "Notepad__push".into(),
             input: json!({
                 "note": "Hello, world!"
             }),
@@ -340,11 +340,11 @@ mod tests {
     async fn test_notepad_in_toolbox() {
         let mut toolbox = ToolBox::default().add(Notepad::new());
         for method in toolbox.methods() {
-            assert_eq!(method.name, "toolbox::Notepad::push");
+            assert_eq!(method.name, "toolbox__Notepad__push");
         }
         let call = Use {
             id: "abcd".into(),
-            name: "toolbox::Notepad::push".into(),
+            name: "toolbox__Notepad__push".into(),
             input: json!({
                 "note": "Hello, world!"
             }),

--- a/misanthropic/src/tool/toolbox.rs
+++ b/misanthropic/src/tool/toolbox.rs
@@ -20,7 +20,7 @@ pub struct ToolBox {
     name: Cow<'static, str>,
     /// Map of [`Method::name`] to tool name of the [`Tool`] to call.
     ///
-    /// Stores namespaced function names in the format `tool::function`.
+    /// Stores namespaced function names in the format `tool__function`.
     pub(crate) method_to_tool_name: BTreeMap<Cow<'static, str>, String>,
     /// Map of tool names to [`Tool`]s.
     pub(crate) tool_name_to_tool: HashMap<String, Box<dyn Tool + Send>>,
@@ -37,6 +37,13 @@ impl Default for ToolBox {
 }
 
 impl ToolBox {
+    /// Separator between namespace segments in a fully-qualified method name
+    /// (`box__tool__method`).
+    ///
+    /// `__` rather than `::` because Anthropic requires tool names to match
+    /// `^[a-zA-Z0-9_-]{1,128}$`, which rejects colons.
+    pub const SEP: &'static str = "__";
+
     /// Create a new [`ToolBox`].
     pub fn new() -> Self {
         Self::default()
@@ -97,7 +104,7 @@ impl ToolBox {
         // Append the function names to self.functions.
         for method in tool.methods() {
             self.method_to_tool_name.insert(
-                format!("{}::{}", self.name, method.name).into(),
+                format!("{}{}{}", self.name, Self::SEP, method.name).into(),
                 tool.name().to_string(),
             );
         }
@@ -134,7 +141,8 @@ impl ToolBox {
         let tool_name = tool.name().to_string();
         let function_names = tool.methods().map(|method| {
             format!(
-                "{self_name}::{tool}::{method}",
+                "{self_name}{sep}{tool}{sep}{method}",
+                sep = Self::SEP,
                 tool = tool.name(),
                 method = method.name
             )
@@ -237,9 +245,13 @@ impl Tool for ToolBox {
         Box::new(self.tool_name_to_tool.values().flat_map(|tool| {
             tool.methods().map(|mut method| {
                 // Append our prefix to the function name, which should already
-                // include `tool::function` format for the function name.
-                method.name =
-                    Cow::Owned(format!("{}::{}", self.name(), method.name));
+                // include `tool__function` format for the function name.
+                method.name = Cow::Owned(format!(
+                    "{}{}{}",
+                    self.name(),
+                    Self::SEP,
+                    method.name
+                ));
                 method
             })
         }))
@@ -410,7 +422,7 @@ mod tests {
 
         fn methods(&self) -> Box<dyn Iterator<Item = Method<'static>> + '_> {
             Box::new(std::iter::once(Method {
-                name: "TestTool::test".into(),
+                name: "TestTool__test".into(),
                 description: "Test Tool".into(),
                 schema: serde_json::json!({
                     "type": "object",
@@ -469,7 +481,7 @@ mod tests {
             .add(TestTool { calls: Vec::new() });
         assert_eq!(
             toolbox.method_to_tool_name.keys().next().unwrap(),
-            "tools::TestTool::test"
+            "tools__TestTool__test"
         );
     }
 
@@ -479,7 +491,7 @@ mod tests {
         let toolbox = ToolBox::new().add(TestTool { calls: Vec::new() });
         let methods = toolbox.methods().collect::<Vec<_>>();
         assert_eq!(methods.len(), 1);
-        assert_eq!(methods[0].name, "toolbox::TestTool::test");
+        assert_eq!(methods[0].name, "toolbox__TestTool__test");
     }
 
     #[tokio::test]
@@ -488,7 +500,7 @@ mod tests {
             ToolBox::new().add_boxed(Box::new(TestTool { calls: Vec::new() }));
         let methods = toolbox.methods().collect::<Vec<_>>();
         assert_eq!(methods.len(), 1);
-        assert_eq!(methods[0].name, "toolbox::TestTool::test");
+        assert_eq!(methods[0].name, "toolbox__TestTool__test");
     }
 
     #[test]
@@ -510,8 +522,8 @@ mod tests {
         );
         let names: Vec<&str> = toolbox.method_names().collect();
         dbg!(&names);
-        assert!(names.contains(&"toolbox::TestTool::test"));
-        assert!(names.contains(&"toolbox::potato::TestTool::test"));
+        assert!(names.contains(&"toolbox__TestTool__test"));
+        assert!(names.contains(&"toolbox__potato__TestTool__test"));
     }
 
     #[test]
@@ -520,7 +532,7 @@ mod tests {
         let tool = TestTool { calls: Vec::new() };
         toolbox.replace(tool);
         let names: Vec<&str> = toolbox.method_names().collect();
-        assert!(names.contains(&"toolbox::TestTool::test"));
+        assert!(names.contains(&"toolbox__TestTool__test"));
     }
 
     #[test]
@@ -535,7 +547,7 @@ mod tests {
         let toolbox = ToolBox::new().add(TestTool { calls: Vec::new() });
         let methods: Vec<Method> = toolbox.methods().collect();
         assert_eq!(methods.len(), 1);
-        assert_eq!(methods[0].name, "toolbox::TestTool::test");
+        assert_eq!(methods[0].name, "toolbox__TestTool__test");
     }
 
     #[tokio::test]
@@ -543,7 +555,7 @@ mod tests {
         let mut toolbox = ToolBox::new().add(TestTool { calls: Vec::new() });
         let call = Use {
             id: "id".into(),
-            name: "toolbox::TestTool::test".into(),
+            name: "toolbox__TestTool__test".into(),
             input: serde_json::json!({}),
             cache_control: None,
         };
@@ -554,14 +566,14 @@ mod tests {
         // Test call with an invalid method.
         let result = toolbox
             .call(Use {
-                name: "toolbox::TestTool::invalid".into(),
+                name: "toolbox__TestTool__invalid".into(),
                 ..call.clone()
             })
             .await;
         assert!(result.is_error);
         assert_eq!(
             result.content,
-            "Method `toolbox::TestTool::invalid` not found in ToolBox `toolbox`. This is almost certainly the developer's fault. Available methods: toolbox::TestTool::test"
+            "Method `toolbox__TestTool__invalid` not found in ToolBox `toolbox`. This is almost certainly the developer's fault. Available methods: toolbox__TestTool__test"
                 .into()
         )
     }


### PR DESCRIPTION
Anthropic tightened the tool-name regex to `^[a-zA-Z0-9_-]{1,128}$`, which rejects `::`. ToolBox namespaced member-tool methods with `::`, and Notepad named its own method `Notepad::push` — both now fail at request time with a 400.

Switch the separator convention to `__` (also the MCP convention, e.g. `mcp__server__tool`).

## Changes
- `ToolBox::SEP` const (`"__"`), documented with the regex reason, used at the three join sites (`push_boxed`, `replace_boxed`, `methods`).
- Nested ToolBoxes still work — routing is a direct `BTreeMap<full_name, tool>` lookup, never a name parse, so `toolbox__potato__TestTool__test` resolves fine.
- Notepad: `Notepad::push` → `Notepad__push` (method name + the `ends_with` dispatch guard).
- Tests updated to the new names.

## Deferred
`memory_palace` still uses `::` in its method names. It's Postgres-gated, already non-functional without a DB, and slated for extraction into its own crate, so it's left for that move rather than churned here.

## Note
This changes serialized tool names, so it's a format break for any persisted `Prompt`/tool state keyed on the old `::` names — acceptable pre-1.0.

## Verification
`cargo test -p misanthropic` (209) and `--features notepad,log` (217) green; `cargo fmt --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)