### PR TITLE
Port chat demo to Dioxus 0.7 (fixes #66)

### DIFF
--- a/chat/frontend/Cargo.toml
+++ b/chat/frontend/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-dioxus = { version = "0.6", features = ["router"] }
+dioxus = { version = "0.7", features = ["router"] }
 eventsource-stream = "0.2"
 reqwest = { version = "0.12", features = [
     "json",
@@ -29,7 +29,7 @@ serde-wasm-bindgen = "0.4"
 wasm-logger = "0.2"
 wasm-bindgen = "0.2"
 wasm-bindgen-futures = "0.4"
-web-sys = { version = "0.3" }
+web-sys = { version = "0.3", features = ["Storage"] }
 thiserror = "1"
 js-sys = "0.3"
 futures = "0.3"
@@ -37,7 +37,14 @@ lazy_static = "1"
 
 # This is the model crate, which is shared between the frontend and backend.
 model = { path = "../model" }
-dioxus-sdk = { version = "0.6", features = ["storage", "system_theme"] }
+
+# misanthropic pulls in `uuid` 1.x; since uuid 1.11 its `v4` feature no longer
+# implies a RNG backend, so on wasm we must opt into one. `js` gives uuid its
+# own wasm-bindgen backend (no `getrandom_backend` cfg needed). Features are
+# additive, so this enables the backend on the shared uuid build without
+# touching native targets or the library's own dependency.
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+uuid = { version = "1", features = ["js"], default-features = false }
 
 [features]
 default = ["web"]

--- a/chat/frontend/src/utils.rs
+++ b/chat/frontend/src/utils.rs
@@ -1,3 +1,31 @@
+/// The browser's `localStorage`, if available (it isn't in every context,
+/// e.g. some private-mode configurations).
+fn local_storage() -> Option<web_sys::Storage> {
+    web_sys::window()?.local_storage().ok().flatten()
+}
+
+/// Read a string from `localStorage` by `key`, or [`None`] if absent or
+/// unavailable.
+pub fn storage_get(key: &str) -> Option<String> {
+    local_storage()?.get_item(key).ok().flatten()
+}
+
+/// Write a string to `localStorage` under `key`. A no-op (with a warning) if
+/// storage is unavailable or the write is rejected (e.g. quota exceeded).
+///
+/// Unlike `dioxus_sdk`'s reactive `use_storage`, this writes synchronously and
+/// eagerly — no spawned watcher task to (fail to) flush. See issue #66.
+pub fn storage_set(key: &str, value: &str) {
+    match local_storage() {
+        Some(storage) => {
+            if let Err(e) = storage.set_item(key, value) {
+                log::warn!("Failed to write `{key}` to localStorage: {e:?}");
+            }
+        }
+        None => log::warn!("localStorage unavailable; `{key}` not persisted."),
+    }
+}
+
 /// https://users.rust-lang.org/t/async-sleep-in-rust-wasm32/78218/6
 pub async fn sleep_ms(delay: i32) {
     let mut cb = |resolve: js_sys::Function, _reject: js_sys::Function| {

--- a/chat/frontend/src/views/chat.rs
+++ b/chat/frontend/src/views/chat.rs
@@ -2,7 +2,6 @@ use std::ops::Deref;
 
 use dioxus::{html::HasFileData, prelude::*};
 
-use dioxus_sdk::storage::{use_storage, LocalStorage};
 use misanthropic::{
     dioxus::{
         opts::{self, HeadingLevel},
@@ -31,6 +30,11 @@ const CSS: Asset = asset!("/assets/styling/chat.css");
 static CLIENT: GlobalSignal<crate::client::Client> =
     GlobalSignal::new(crate::client::Client::new);
 const BASE64: GeneralPurpose = base64::engine::general_purpose::STANDARD;
+/// `localStorage` key under which the toolbox state is persisted across
+/// sessions. `localStorage` (not `sessionStorage`): the notepad's whole point
+/// is recalling notes from *other* sessions, so state must survive a tab or
+/// browser close and be shared across tabs.
+const TOOLBOX_STATE_KEY: &str = "toolbox-state";
 static DEFAULT_DRAG_CLOSURE: GlobalSignal<
     Closure<dyn FnMut(web_sys::DragEvent)>,
 > = GlobalSignal::new(|| {
@@ -83,19 +87,23 @@ fn is_empty_tool_state(state: &serde_json::Value) -> bool {
         .unwrap_or(true)
 }
 
-/// Serialize the toolbox and write it to the persistent store — unless it's
+/// Serialize the toolbox and write it to `localStorage` — unless it's
 /// [`is_empty_tool_state`], in which case we leave existing storage untouched.
-/// Signals are `Copy`, so both are taken by value.
-async fn persist_tool_state(
-    mut toolbox: Signal<misanthropic::tool::ToolBox>,
-    mut toolbox_state: Signal<serde_json::Value>,
-) {
+/// Signals are `Copy`, so the toolbox is taken by value.
+///
+/// Writes go straight to `localStorage` via [`crate::utils::storage_set`]
+/// rather than through `dioxus_sdk`'s reactive `use_storage`, whose spawned
+/// watcher task failed to flush our `.set()` under the 0.7 runtime (issue #66).
+async fn persist_tool_state(mut toolbox: Signal<misanthropic::tool::ToolBox>) {
     let saved = toolbox.write().save_json().await;
     if is_empty_tool_state(&saved) {
         log::debug!("Tool state is empty; leaving stored state untouched.");
         return;
     }
-    toolbox_state.set(saved);
+    match serde_json::to_string(&saved) {
+        Ok(json) => crate::utils::storage_set(TOOLBOX_STATE_KEY, &json),
+        Err(e) => log::warn!("Failed to serialize tool state: {e}"),
+    }
 }
 
 /// A test prompt for testing the chat view.
@@ -240,13 +248,6 @@ pub fn Chat() -> Element {
     let mut show_system = use_signal(|| false);
     let mut show_thought = use_signal(|| false);
     let mut show_tool_use = use_signal(|| false);
-    // `LocalStorage`, not `use_persistent` (which is `SessionStorage` — dies
-    // with the tab and isn't shared across tabs). The notepad's whole point is
-    // notes from *other sessions*, so it needs to survive a tab/browser close.
-    let toolbox_state =
-        use_storage::<LocalStorage, _>("toolbox-state".to_string(), || {
-            serde_json::Value::Null
-        });
     // Created un-loaded; persisted state is restored asynchronously as the
     // first step of the stream task (see below), before the first prompt is
     // requested. Doing it here would require `block_on`, which only works for
@@ -277,24 +278,19 @@ pub fn Chat() -> Element {
     // Our long-running task is the stream task. It will run until the
     // component is dropped, connecting with the
     let _stream_task = use_resource(move || async move {
-        // Restore persisted tool state once, before connecting. `peek()` (not
-        // `read()`) so this resource doesn't subscribe to `toolbox_state` —
-        // it's `.set()` on every tool call, and subscribing would restart the
-        // whole stream each time. Outside the reconnect `loop` so a reconnect
-        // never clobbers in-session tool state with the last snapshot.
+        // Restore persisted tool state once, before connecting. Read directly
+        // from `localStorage` (not a reactive signal) so this resource doesn't
+        // subscribe to anything written on every tool call — subscribing would
+        // restart the whole stream each time. Outside the reconnect `loop` so a
+        // reconnect never clobbers in-session tool state with the last snapshot.
+        let stored = crate::utils::storage_get(TOOLBOX_STATE_KEY)
+            .and_then(|s| serde_json::from_str::<serde_json::Value>(&s).ok())
+            .unwrap_or(serde_json::Value::Null);
         log::info!(
             "Restoring tool state from storage ({}).",
-            if toolbox_state.peek().is_null() {
-                "empty"
-            } else {
-                "present"
-            }
+            if stored.is_null() { "empty" } else { "present" }
         );
-        if let Err(e) = toolbox
-            .write()
-            .load_json(toolbox_state.peek().clone())
-            .await
-        {
+        if let Err(e) = toolbox.write().load_json(stored).await {
             log::error!("`Toolbox::load_json` had error(s): {e}");
         } else {
             log::info!("Toolbox state loaded.");
@@ -345,8 +341,7 @@ pub fn Chat() -> Element {
                                         .write()
                                         .call(tool_use.clone())
                                         .await;
-                                    persist_tool_state(toolbox, toolbox_state)
-                                        .await;
+                                    persist_tool_state(toolbox).await;
                                     log::info!("Tool result: {:?}", result);
 
                                     // We send the result back to the server.
@@ -510,6 +505,10 @@ pub fn Chat() -> Element {
         div {
             class: "input",
             form {
+                // Dioxus 0.7 submits forms by default (0.6 prevented it); we
+                // drive sending from the textarea's Enter handler, so suppress
+                // the native submit/reload here.
+                onsubmit: move |e| e.prevent_default(),
                 textarea {
                     class: "input-box",
                     class: if *dragged_over.read() {
@@ -559,18 +558,18 @@ pub fn Chat() -> Element {
                     ondragover: move |e| {
                         e.prevent_default();
                         dragged_over.set(true);
-                        if let Some(files) = e.files() {
-                            let filenames = files.files();
-                            if filenames.len() != 1 {
-                                dragged_file_supported.set(false);
-                                return;
-                            }
-                            let filename = &filenames[0];
-                            if MediaType::is_supported(filename) || filename.ends_with(".json") {
-                                dragged_file_supported.set(true);
-                            } else {
-                                dragged_file_supported.set(false);
-                            }
+                        // Dioxus 0.7: `files()` returns `Vec<FileData>` directly
+                        // (0.6 returned an `Option<FileEngine>`).
+                        let files = e.files();
+                        if files.len() != 1 {
+                            dragged_file_supported.set(false);
+                            return;
+                        }
+                        let filename = files[0].name();
+                        if MediaType::is_supported(&filename) || filename.ends_with(".json") {
+                            dragged_file_supported.set(true);
+                        } else {
+                            dragged_file_supported.set(false);
                         }
                     },
                     ondragleave: move |e| {
@@ -583,133 +582,137 @@ pub fn Chat() -> Element {
                         e.stop_propagation();
                         dragged_over.set(false);
                         dragged_file_supported.set(false);
-                        if let Some(files) = e.files() {
-                            let filenames = files.files();
-                            if filenames.len() == 0 {
-                                log::warn!("No files dropped.");
-                                return;
-                            } else if filenames.len() > 1 {
-                                log::warn!("Only one file can be dropped at a time.");
-                                return;
-                            }
-                            // len is 1
-                            let filename = &filenames[0];
+                        // Dioxus 0.7: `files()` returns `Vec<FileData>` directly
+                        // (0.6 returned an `Option<FileEngine>`), and each file
+                        // is read with `FileData::read_bytes`.
+                        let files = e.files();
+                        if files.is_empty() {
+                            log::warn!("No files dropped.");
+                            return;
+                        } else if files.len() > 1 {
+                            log::warn!("Only one file can be dropped at a time.");
+                            return;
+                        }
+                        // len is 1
+                        let file = &files[0];
+                        let filename = file.name();
 
-                            // Is the file a JSON file? We need to load it, set
-                            // the tools, and send the updated prompt to the
-                            // backend.
-                            if filename.ends_with(".json") {
-                                let data = if let Some(data) = files.read_file(filename).await {
-                                    data
-                                } else {
-                                    log::warn!("Failed to read file.");
-                                    return;
-                                };
-
-                                if data.is_empty() {
-                                    log::warn!("Empty file.");
+                        // Is the file a JSON file? We need to load it, set
+                        // the tools, and send the updated prompt to the
+                        // backend.
+                        if filename.ends_with(".json") {
+                            let data = match file.read_bytes().await {
+                                Ok(data) => data,
+                                Err(e) => {
+                                    log::warn!("Failed to read file: {e}");
                                     return;
                                 }
-
-                                // Sniff whether this is a saved conversation or
-                                // saved tool state by shape (Save writes them as
-                                // separate files). See `Dropped`.
-                                match serde_json::from_slice::<Dropped>(&data) {
-                                    Ok(Dropped::Prompt(new_prompt)) => {
-                                        log::info!("Loading new prompt.");
-                                        let mut new_prompt = *new_prompt;
-
-                                        // Tool definitions track the app's
-                                        // current capabilities, not whatever the
-                                        // loaded (possibly foreign or older)
-                                        // prompt carried. `prepare` overwrites
-                                        // `methods` and runs each tool's
-                                        // `on_init`, so old/foreign prompts just
-                                        // work.
-                                        if let Err(e) = toolbox.write().prepare(&mut new_prompt).await {
-                                            log::error!("`Toolbox::prepare` had error(s): {e}");
-                                        } else {
-                                            log::info!("Toolbox prepared.");
-                                        }
-
-                                        match CLIENT.read().send(
-                                            Request::SetPrompt(new_prompt.clone())
-                                        ).await {
-                                            Ok(_) => {
-                                                prompt.set(new_prompt);
-                                            }
-                                            Err(e) => {
-                                                log::error!("Failed to set prompt: {}", e);
-                                            }
-                                        }
-                                    }
-                                    Ok(Dropped::ToolState(state)) => {
-                                        log::info!("Loading tool state.");
-                                        let value = match serde_json::to_value(state) {
-                                            Ok(value) => value,
-                                            Err(e) => {
-                                                log::warn!("Failed to re-encode tool state: {}", e);
-                                                return;
-                                            }
-                                        };
-                                        if let Err(e) = toolbox.write().load_json(value).await {
-                                            log::warn!("Failed to load tool state: {}", e);
-                                        } else {
-                                            log::info!("Tool state loaded.");
-                                        }
-                                        persist_tool_state(toolbox, toolbox_state).await;
-
-                                        // Re-apply to the current prompt so newly
-                                        // loaded notes appear in the system block,
-                                        // then push the update to the backend.
-                                        let mut new_prompt = prompt.peek().clone();
-                                        if let Err(e) = toolbox.write().prepare(&mut new_prompt).await {
-                                            log::error!("`Toolbox::prepare` had error(s): {e}");
-                                        }
-                                        match CLIENT.read().send(
-                                            Request::SetPrompt(new_prompt.clone())
-                                        ).await {
-                                            Ok(_) => {
-                                                prompt.set(new_prompt);
-                                            }
-                                            Err(e) => {
-                                                log::error!("Failed to set prompt after tool state load: {}", e);
-                                            }
-                                        }
-                                    }
-                                    Err(e) => {
-                                        log::warn!("Dropped .json is neither a prompt nor tool state: {}", e);
-                                    }
-                                }
-
-                                return;
-                            }
-
-
-                            let format = if let Some(format) =  MediaType::detect(&filename) {
-                                format
-                            } else {
-                                log::warn!("Unsupported file type.");
-                                return;
-                            };
-
-                            let data = if let Some(data) = files.read_file(filename).await {
-                                data
-                            } else {
-                                log::warn!("Failed to read file.");
-                                return;
                             };
 
                             if data.is_empty() {
                                 log::warn!("Empty file.");
                                 return;
                             }
-                            // We have a file data with a supported format. Load
-                            // it and push it to the attachments.
 
-                            let image = Image::from_compressed(format, data);
-                            attachments.write().push(image.into());
+                            // Sniff whether this is a saved conversation or
+                            // saved tool state by shape (Save writes them as
+                            // separate files). See `Dropped`.
+                            match serde_json::from_slice::<Dropped>(&data) {
+                                Ok(Dropped::Prompt(new_prompt)) => {
+                                    log::info!("Loading new prompt.");
+                                    let mut new_prompt = *new_prompt;
+
+                                    // Tool definitions track the app's
+                                    // current capabilities, not whatever the
+                                    // loaded (possibly foreign or older)
+                                    // prompt carried. `prepare` overwrites
+                                    // `methods` and runs each tool's
+                                    // `on_init`, so old/foreign prompts just
+                                    // work.
+                                    if let Err(e) = toolbox.write().prepare(&mut new_prompt).await {
+                                        log::error!("`Toolbox::prepare` had error(s): {e}");
+                                    } else {
+                                        log::info!("Toolbox prepared.");
+                                    }
+
+                                    match CLIENT.read().send(
+                                        Request::SetPrompt(new_prompt.clone())
+                                    ).await {
+                                        Ok(_) => {
+                                            prompt.set(new_prompt);
+                                        }
+                                        Err(e) => {
+                                            log::error!("Failed to set prompt: {}", e);
+                                        }
+                                    }
+                                }
+                                Ok(Dropped::ToolState(state)) => {
+                                    log::info!("Loading tool state.");
+                                    let value = match serde_json::to_value(state) {
+                                        Ok(value) => value,
+                                        Err(e) => {
+                                            log::warn!("Failed to re-encode tool state: {}", e);
+                                            return;
+                                        }
+                                    };
+                                    if let Err(e) = toolbox.write().load_json(value).await {
+                                        log::warn!("Failed to load tool state: {}", e);
+                                    } else {
+                                        log::info!("Tool state loaded.");
+                                    }
+                                    persist_tool_state(toolbox).await;
+
+                                    // Re-apply to the current prompt so newly
+                                    // loaded notes appear in the system block,
+                                    // then push the update to the backend.
+                                    let mut new_prompt = prompt.peek().clone();
+                                    if let Err(e) = toolbox.write().prepare(&mut new_prompt).await {
+                                        log::error!("`Toolbox::prepare` had error(s): {e}");
+                                    }
+                                    match CLIENT.read().send(
+                                        Request::SetPrompt(new_prompt.clone())
+                                    ).await {
+                                        Ok(_) => {
+                                            prompt.set(new_prompt);
+                                        }
+                                        Err(e) => {
+                                            log::error!("Failed to set prompt after tool state load: {}", e);
+                                        }
+                                    }
+                                }
+                                Err(e) => {
+                                    log::warn!("Dropped .json is neither a prompt nor tool state: {}", e);
+                                }
+                            }
+
+                            return;
                         }
+
+
+                        let format = if let Some(format) =  MediaType::detect(&filename) {
+                            format
+                        } else {
+                            log::warn!("Unsupported file type.");
+                            return;
+                        };
+
+                        let data = match file.read_bytes().await {
+                            Ok(data) => data,
+                            Err(e) => {
+                                log::warn!("Failed to read file: {e}");
+                                return;
+                            }
+                        };
+
+                        if data.is_empty() {
+                            log::warn!("Empty file.");
+                            return;
+                        }
+                        // We have a file data with a supported format. Load
+                        // it and push it to the attachments.
+
+                        let image = Image::from_compressed(format, data);
+                        attachments.write().push(image.into());
                     }
                 }
             }

--- a/misanthropic/Cargo.toml
+++ b/misanthropic/Cargo.toml
@@ -105,7 +105,7 @@ chrono = { version = "0.4", features = ["serde"] }
 # for request ids
 uuid = { version = "1", features = ["v4", "serde"] }
 # Dioxus support
-dioxus = { version = "0.6", optional = true }
+dioxus = { version = "0.7", optional = true }
 # JSON Schema generation for structured outputs and typed tools. Core: tool
 # calling is a core feature, so schemars is non-optional.
 schemars = { version = "1" }

--- a/misanthropic/src/dioxus.rs
+++ b/misanthropic/src/dioxus.rs
@@ -82,28 +82,28 @@ pub mod opts {
         pub fn element<'a>(self, key: u64, content: Cow<'a, str>) -> Element {
             match self {
                 HeadingLevel::H1 => rsx!(h1 {
-                    key: key,
-                    {content}
+                    key: "{key}",
+                    "{content}"
                 }),
                 HeadingLevel::H2 => rsx!(h2 {
-                    key: key,
-                    {content}
+                    key: "{key}",
+                    "{content}"
                 }),
                 HeadingLevel::H3 => rsx!(h3 {
-                    key: key,
-                    {content}
+                    key: "{key}",
+                    "{content}"
                 }),
                 HeadingLevel::H4 => rsx!(h4 {
-                    key: key,
-                    {content}
+                    key: "{key}",
+                    "{content}"
                 }),
                 HeadingLevel::H5 => rsx!(h5 {
-                    key: key,
-                    {content}
+                    key: "{key}",
+                    "{content}"
                 }),
                 HeadingLevel::H6 => rsx!(h6 {
-                    key: key,
-                    {content}
+                    key: "{key}",
+                    "{content}"
                 }),
             }
         }
@@ -266,16 +266,16 @@ impl IntoElement for ThoughtOrSpeech<'_> {
                 opts::Thought::Hidden => rsx!(),
                 opts::Thought::Placeholder { class } => {
                     rsx!(div {
-                        key: key,
+                        key: "{key}",
                         class: class.as_ref(),
                         "Thinking..."
                     })
                 }
                 opts::Thought::Show { class } => {
                     rsx!(div {
-                        key: key,
+                        key: "{key}",
                         class: class.as_ref(),
-                        {thought}
+                        "{thought}"
                     })
                 }
             },
@@ -283,15 +283,15 @@ impl IntoElement for ThoughtOrSpeech<'_> {
                 opts::Speech::Hidden => rsx!(),
                 opts::Speech::Placeholder { class } => {
                     rsx!(div {
-                        key: key,
+                        key: "{key}",
                         class: class.as_ref(),
                     })
                 }
                 opts::Speech::Show { class } => {
                     rsx!(div {
-                        key: key,
+                        key: "{key}",
                         class: class.as_ref(),
-                        {speech}
+                        "{speech}"
                     })
                 }
             },
@@ -322,7 +322,7 @@ impl IntoElement for &Block<'_> {
                 #[cfg(not(feature = "cot"))]
                 {
                     rsx!(div {
-                        key: key,
+                        key: "{key}",
                         class: "text",
                         class: if cache_control.is_some() { "cache" } else { "" },
                         {text.as_ref()}
@@ -336,17 +336,17 @@ impl IntoElement for &Block<'_> {
                 opts::Thought::Hidden => rsx!(),
                 opts::Thought::Placeholder { class } => {
                     rsx!(div {
-                        key: key,
+                        key: "{key}",
                         id: signature.as_ref(),
                         class: class.as_ref(),
                     })
                 }
                 opts::Thought::Show { class } => {
                     rsx!(div {
-                        key: key,
+                        key: "{key}",
                         id: signature.as_ref(),
                         class: class.as_ref(),
-                        {thinking}
+                        "{thinking}"
                     })
                 }
             },
@@ -354,14 +354,14 @@ impl IntoElement for &Block<'_> {
                 opts::Thought::Hidden => rsx!(),
                 opts::Thought::Placeholder { class } => {
                     rsx!(div {
-                        key: key,
+                        key: "{key}",
                         id: signature.as_ref(),
                         class: class.as_ref(),
                     })
                 }
                 opts::Thought::Show { class } => {
                     rsx!(div {
-                        key: key,
+                        key: "{key}",
                         id: signature.as_ref(),
                         class: format!("{} redacted", class),
                         "Anthropic redacted a thought."
@@ -375,13 +375,13 @@ impl IntoElement for &Block<'_> {
                 opts::Image::Hidden => rsx!(),
                 opts::Image::Placeholder { class } => {
                     rsx!(div {
-                        key: key,
+                        key: "{key}",
                         class: class.as_ref(),
                     })
                 }
                 opts::Image::Show { class } => {
                     rsx!(img {
-                        key: key,
+                        key: "{key}",
                         class: class.as_ref(),
                         src: {
                             match image {
@@ -400,7 +400,7 @@ impl IntoElement for &Block<'_> {
                 opts::ToolUse::Hidden => rsx!(),
                 opts::ToolUse::Placeholder { show_name, class } => {
                     rsx!(div {
-                        key: key,
+                        key: "{key}",
                         class: class.as_ref(),
                         {show_name.map(
                             |level| level.element(key, call.name.as_ref().into()
@@ -409,7 +409,7 @@ impl IntoElement for &Block<'_> {
                 }
                 opts::ToolUse::Show { show_name, class } => {
                     rsx!(code {
-                        key: key,
+                        key: "{key}",
                         lang: "json",
                         class: class.as_ref(),
                         {serde_json::to_string_pretty(call).unwrap()}
@@ -420,7 +420,7 @@ impl IntoElement for &Block<'_> {
                 opts::ToolResult::Hidden => rsx!(),
                 opts::ToolResult::Placeholder { error, ok } => {
                     rsx!(div {
-                        key: key,
+                        key: "{key}",
                         title: if result.is_error { "Error" } else { "Ok" },
                         class: if result.is_error {
                             error.as_ref()
@@ -431,7 +431,7 @@ impl IntoElement for &Block<'_> {
                 }
                 opts::ToolResult::Show { error, ok } => {
                     rsx!(code {
-                        key: key,
+                        key: "{key}",
                         title: if result.is_error { "Error" } else { "Ok" },
                         lang: "json",
                         class: if result.is_error {
@@ -450,7 +450,7 @@ impl IntoElement for &Block<'_> {
 impl IntoElement for &message::Content<'_> {
     fn into_element_custom(self, key: u64, opts: &Options) -> Element {
         rsx!(div {
-            key: key,
+            key: "{key}",
             class: "multi-part",
             {self
                 .iter()
@@ -463,7 +463,7 @@ impl IntoElement for &message::Content<'_> {
 impl IntoElement for &message::Message<'_> {
     fn into_element_custom(self, key: u64, opts: &Options) -> Element {
         rsx!(div {
-            key: key,
+            key: "{key}",
             class: if self.tool_result().is_some() {
                 // We lie, because it really should be a separate role and it's
                 // much easier to format this way.
@@ -482,14 +482,15 @@ impl IntoElement for &message::Message<'_> {
                 match &opts.speech {
                     opts::Speech::Hidden => rsx!(),
                     opts::Speech::Placeholder { class } => {
+                        let k = hash(&[key, 0]);
                         rsx!(div {
-                            key: hash(&[key, 0]),
+                            key: "{k}",
                             class: class.as_ref(),
                         })
                     }
                     opts::Speech::Show { class } => {
                         rsx!(div {
-                            key: key,
+                            key: "{key}",
                             class: class.as_ref(),
                             {self.content
                                 .iter()
@@ -500,7 +501,7 @@ impl IntoElement for &message::Message<'_> {
                 }
             } else {
                 rsx!(div {
-                    key: key,
+                    key: "{key}",
                     class: "multi-part",
                     {self.content
                         .iter()
@@ -514,22 +515,25 @@ impl IntoElement for &message::Message<'_> {
 
 impl IntoElement for &prompt::Prompt<'_> {
     fn into_element_custom(self, key: u64, opts: &Options) -> Element {
+        let messages_key = hash(&[key, 2]);
         rsx!(
             div {
-                key: key,
+                key: "{key}",
                 class: "prompt",
                 if let Some(system) = &self.system {
                     match &opts.system {
                         opts::System::Hidden => rsx!(),
                         opts::System::Placeholder { class } => {
+                            let k = hash(&[key, 1]);
                             rsx!(div {
-                                key: hash(&[key, 1]),
+                                key: "{k}",
                                 class: class.as_ref(),
                             })
                         }
                         opts::System::Show { class } => {
+                            let k = hash(&[key, 0]);
                             rsx!(div {
-                                key: hash(&[key, 0]),
+                                key: "{k}",
                                 class: class.as_ref(),
                                 {system.into_element_custom(hash(&[key, 1]), opts)}
                             })
@@ -537,7 +541,7 @@ impl IntoElement for &prompt::Prompt<'_> {
                     }
                 }
                 div {
-                    key: hash(&[key, 2]),
+                    key: "{messages_key}",
                     class: "messages",
                     {(2..).zip(self.messages.iter()).map(|(i, message)| {
                         message.into_element_custom(hash(&[key, i as u64]), opts)


### PR DESCRIPTION
## Summary

Ports the `chat/` demo from Dioxus 0.6 to **0.7** and fixes the tool-state persistence bug (#66) as part of it. Verified end-to-end: `dx build` succeeds under dx/dioxus 0.7.9, all tests pass, and in a live run the CSS breakage is gone and Notepad notes now survive page reloads.

### Library (`misanthropic`)
- Bump the optional `dioxus` dep 0.6 → 0.7 and update `dioxus.rs` for the 0.7 rsx API:
  - `key:` now requires a formatted string (`key: "{value}"`); hash-computed keys are bound to a local first since rsx format strings can't call functions.
  - `Cow` / `cot::Thought` / `cot::Speech` lost their `IntoDynNode` impl, so text interpolations use the `Display`-based string-node form (`"{value}"`).

### Frontend (`chat/frontend`)
- Bump `dioxus` 0.6 → 0.7. Forms submit by default in 0.7, so the input form gets `onsubmit: prevent_default`.
- Drag/drop `files()` now returns `Vec<FileData>` (was `Option<FileEngine>`); dropped files are read via `FileData::read_bytes`.
- Enable uuid's `js` RNG backend on wasm (uuid 1.11+ no longer implies one from `v4`), scoped to `cfg(target_arch = "wasm32")`.

### Fix #66 — tool state lost on reload
`dioxus_sdk`'s reactive `use_storage` watcher task never flushed our `.set()` to `localStorage` under the 0.7 runtime. Dropped `dioxus_sdk` entirely (storage was its only use here) and now read/write `localStorage` directly via small `web_sys` helpers in `utils`. The write is synchronous and eager, so there's no watcher task to miss it; `toolbox_state` no longer needs to be a `Signal`.

## Test plan
- `dx build --platform web` (dx 0.7.9): full bundle succeeds.
- `cargo check -p chat-frontend --target wasm32-unknown-unknown`: clean.
- Native `misanthropic` (+`dioxus`), `chat-backend`, `model`: build clean.
- `cargo test -p misanthropic` across the feature matrix: 273 passed, 7 ignored.
- `cargo fmt --all -- --check`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)