### PR TITLE
Reactive rate limiting: drop governor, surface retry-after (#33)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .vscode
+.claude/
 *.env
 target/
 api.key

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,7 +89,7 @@ self-describing (`StopReason::EndTurn`).
 
 ## Key features to know about
 
-Default features: `rustls-tls`, `langsan`, `rate-limiting`, `client`, `batch`.
+Default features: `rustls-tls`, `langsan`, `client`, `batch`.
 
 Notable optional features: `prompt-caching`, `markdown`, `html`, `memsecurity`,
 `dioxus`, `memory-palace` (requires PostgreSQL), `notepad`, `cot`.

--- a/chat/backend/src/endpoints.rs
+++ b/chat/backend/src/endpoints.rs
@@ -198,10 +198,6 @@ pub async fn events_stream(
             // full messages and tool use events.
             let stream = match state.client.stream(prompt.deref()).await {
                 Ok(stream) => stream
-                    // Anthropic is sending *us* messages so this is not very
-                    // important, however with many users it might be useful to
-                    // include rate limit errors.
-                    .filter_rate_limit()
                     // Adds a full message event, `Event::Message` and tool use.
                     .with_message_ip(&mut assistant_message),
                 Err(e) => {

--- a/misanthropic/Cargo.toml
+++ b/misanthropic/Cargo.toml
@@ -96,8 +96,6 @@ langsan = { version = "0", features = [
 xml-rs = { version = "0.8", optional = true }
 # For shuttle-runtime support
 shuttle-runtime = { version = "0.51", optional = true }
-# Rate limiting
-governor = { version = "0.7", optional = true }
 # async/await
 async-stream = "0.3"
 # for date and time parsing
@@ -138,7 +136,7 @@ trybuild = "1"
 
 [features]
 # rustls because I am sick of getting Dependabot alerts for OpenSSL.
-default = ["rustls-tls", "langsan", "rate-limiting", "client", "batch", "derive"]
+default = ["rustls-tls", "langsan", "client", "batch", "derive"]
 # Image crate support. Note that images are supported without this feature but
 # you must handle encoding/decoding yourself, so it almost always makes sense
 # to enable this and use the image crate.
@@ -168,8 +166,6 @@ langsan = ["dep:langsan"]
 # not encrypted. This is a more secure option for the paranoid. Does not build
 # on wasm32.
 memsecurity = ["dep:memsecurity"]
-# Enable client-side rate limiting. This is enabled by default.
-rate-limiting = ["dep:governor"]
 # Support for parsing chain of thought XML tags.
 cot = []
 # Support for shuttle-runtime crate.

--- a/misanthropic/examples/website_wizard.rs
+++ b/misanthropic/examples/website_wizard.rs
@@ -72,10 +72,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
           ],
         }))
         .await?
-        // Filter out rate limit and overloaded errors. This is optional but
-        // recommended for most use cases. The stream will continue when the
-        // server is ready. Otherwise the stream will include these errors.
-        .filter_rate_limit()
         // Filter out everything but text pieces (and errors).
         .text();
 

--- a/misanthropic/src/client.rs
+++ b/misanthropic/src/client.rs
@@ -1355,7 +1355,6 @@ mod tests {
             .unwrap();
 
         let msg: String = stream
-            .filter_rate_limit()
             .text()
             .try_collect()
             .await

--- a/misanthropic/src/client.rs
+++ b/misanthropic/src/client.rs
@@ -226,12 +226,18 @@ impl Client {
     {
         let response = self.get_raw(url).await?;
         let status = response.status();
+        // Grab `retry-after` before `text()` consumes the response.
+        let retry_after = parse_retry_after(response.headers());
         let body = response.text().await?;
 
         if status != reqwest::StatusCode::OK {
             // Error path: try the documented Anthropic shape first.
             return match serde_json::from_str::<AnthropicErrorWrapper>(&body) {
-                Ok(wrapper) => Err(wrapper.error.into()),
+                Ok(wrapper) => {
+                    let mut error = wrapper.error;
+                    error.set_retry_after(retry_after);
+                    Err(error.into())
+                }
                 Err(_parse_err) => {
                     #[cfg(feature = "log")]
                     {
@@ -303,9 +309,15 @@ impl Client {
 
         if response.status() != reqwest::StatusCode::OK {
             let status = response.status();
+            // Grab `retry-after` before `text()` consumes the response.
+            let retry_after = parse_retry_after(response.headers());
             let body = response.text().await?;
             return match serde_json::from_str::<AnthropicErrorWrapper>(&body) {
-                Ok(wrapper) => Err(wrapper.error.into()),
+                Ok(wrapper) => {
+                    let mut error = wrapper.error;
+                    error.set_retry_after(retry_after);
+                    Err(error.into())
+                }
                 Err(_parse_err) => {
                     #[cfg(feature = "log")]
                     {
@@ -708,6 +720,25 @@ where
     }
 }
 
+/// Parse the `retry-after` response header as a whole number of seconds.
+///
+/// Anthropic sends seconds on `429`/`529` responses. The HTTP-date form
+/// of `retry-after` is legal per the spec but Anthropic does not use it,
+/// so we treat anything that isn't a plain integer as `None` rather than
+/// pulling in a date parser. Folded into the parsed [`AnthropicError`]
+/// via [`AnthropicError::set_retry_after`] and surfaced through
+/// [`AnthropicError::retry_after`].
+#[cfg(feature = "client")]
+fn parse_retry_after(headers: &reqwest::header::HeaderMap) -> Option<u64> {
+    headers
+        .get(reqwest::header::RETRY_AFTER)?
+        .to_str()
+        .ok()?
+        .trim()
+        .parse()
+        .ok()
+}
+
 /// Truncate `body` to at most [`NON_JSON_BODY_SNIPPET_LEN`] bytes at a
 /// valid UTF-8 boundary, appending a `... [N more bytes]` suffix if the
 /// body was longer.
@@ -836,13 +867,31 @@ pub enum AnthropicError {
     RequestTooLarge { message: String },
     #[error("rate limit (429): {message}")]
     #[serde(rename = "rate_limit_error")]
-    RateLimit { message: String },
+    RateLimit {
+        message: String,
+        /// Seconds to wait before retrying, taken from the `retry-after`
+        /// response header. `None` if the header was absent or not a
+        /// plain integer. See [`Self::retry_after`] for a [`Duration`].
+        ///
+        /// [`Duration`]: std::time::Duration
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        retry_after: Option<u64>,
+    },
     #[error("api error (500): {message}")]
     #[serde(rename = "api_error")]
     API { message: String },
     #[error("overloaded (529): {message}")]
     #[serde(rename = "overloaded_error")]
-    Overloaded { message: String },
+    Overloaded {
+        message: String,
+        /// Seconds to wait before retrying, taken from the `retry-after`
+        /// response header. `None` if the header was absent or not a
+        /// plain integer. See [`Self::retry_after`] for a [`Duration`].
+        ///
+        /// [`Duration`]: std::time::Duration
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        retry_after: Option<u64>,
+    },
     #[error("timeout: {message}")]
     #[serde(rename = "timeout_error")]
     Timeout { message: String },
@@ -879,6 +928,42 @@ impl AnthropicError {
             Self::Timeout { .. } => None,
         }
     }
+
+    /// Suggested wait before retrying, parsed from the `retry-after`
+    /// response header. Only [`RateLimit`] (429) and [`Overloaded`]
+    /// (529) carry one; every other variant — and any error whose
+    /// header was absent or unparseable — returns `None`.
+    ///
+    /// A `Some(_)` here is the crate's signal that the error is worth
+    /// retrying, and for how long.
+    ///
+    /// [`RateLimit`]: Self::RateLimit
+    /// [`Overloaded`]: Self::Overloaded
+    pub fn retry_after(&self) -> Option<std::time::Duration> {
+        match self {
+            Self::RateLimit { retry_after, .. }
+            | Self::Overloaded { retry_after, .. } => {
+                retry_after.map(std::time::Duration::from_secs)
+            }
+            _ => None,
+        }
+    }
+
+    /// Set the `retry-after` hint (in seconds) on the variants that
+    /// carry one ([`RateLimit`], [`Overloaded`]); a no-op for all
+    /// others. Used by the client to fold the response header into the
+    /// parsed error body.
+    ///
+    /// [`RateLimit`]: Self::RateLimit
+    /// [`Overloaded`]: Self::Overloaded
+    #[cfg(feature = "client")]
+    pub(crate) fn set_retry_after(&mut self, seconds: Option<u64>) {
+        if let Self::RateLimit { retry_after, .. }
+        | Self::Overloaded { retry_after, .. } = self
+        {
+            *retry_after = seconds;
+        }
+    }
 }
 
 /// Custom `Deserialize` impl so unknown `type` values fall through to
@@ -912,9 +997,15 @@ impl<'de> Deserialize<'de> for AnthropicError {
             "permission_error" => Self::Permission { message },
             "not_found_error" => Self::NotFound { message },
             "request_too_large" => Self::RequestTooLarge { message },
-            "rate_limit_error" => Self::RateLimit { message },
+            "rate_limit_error" => Self::RateLimit {
+                message,
+                retry_after: None,
+            },
             "api_error" => Self::API { message },
-            "overloaded_error" => Self::Overloaded { message },
+            "overloaded_error" => Self::Overloaded {
+                message,
+                retry_after: None,
+            },
             "timeout_error" => Self::Timeout { message },
             unknown => Self::Unknown {
                 code: None,
@@ -1069,7 +1160,8 @@ mod tests {
         assert_eq!(
             error,
             AnthropicError::RateLimit {
-                message: "Rate limit exceeded".to_string()
+                message: "Rate limit exceeded".to_string(),
+                retry_after: None,
             }
         );
 
@@ -1089,7 +1181,8 @@ mod tests {
         assert_eq!(
             error,
             AnthropicError::Overloaded {
-                message: "Service overloaded".to_string()
+                message: "Service overloaded".to_string(),
+                retry_after: None,
             }
         );
 
@@ -1176,6 +1269,104 @@ mod tests {
             message: "Batch result expired".to_string(),
         };
         assert_eq!(e.status(), Some(NonZeroU16::new(408).unwrap()));
+    }
+
+    // Reactive retry-after handling (issue #33).
+
+    #[test]
+    fn test_retry_after_accessor() {
+        use std::time::Duration;
+
+        // Only RateLimit / Overloaded expose a hint, as a Duration.
+        let e = AnthropicError::RateLimit {
+            message: "slow down".to_string(),
+            retry_after: Some(30),
+        };
+        assert_eq!(e.retry_after(), Some(Duration::from_secs(30)));
+
+        let o = AnthropicError::Overloaded {
+            message: "busy".to_string(),
+            retry_after: None,
+        };
+        assert_eq!(o.retry_after(), None);
+
+        // Variants without the field always return None.
+        let other = AnthropicError::API {
+            message: "boom".to_string(),
+        };
+        assert_eq!(other.retry_after(), None);
+    }
+
+    #[cfg(feature = "client")]
+    #[test]
+    fn test_set_retry_after() {
+        use std::time::Duration;
+
+        let mut e = AnthropicError::RateLimit {
+            message: "slow down".to_string(),
+            retry_after: None,
+        };
+        e.set_retry_after(Some(30));
+        assert_eq!(e.retry_after(), Some(Duration::from_secs(30)));
+
+        let mut o = AnthropicError::Overloaded {
+            message: "busy".to_string(),
+            retry_after: None,
+        };
+        o.set_retry_after(Some(5));
+        assert_eq!(o.retry_after(), Some(Duration::from_secs(5)));
+
+        // No-op on variants without the field.
+        let mut other = AnthropicError::API {
+            message: "boom".to_string(),
+        };
+        other.set_retry_after(Some(99));
+        assert_eq!(other.retry_after(), None);
+    }
+
+    #[test]
+    fn test_retry_after_serde_roundtrip() {
+        // Absent hint is skipped on serialize and round-trips to None.
+        let none = AnthropicError::RateLimit {
+            message: "x".to_string(),
+            retry_after: None,
+        };
+        let json = serde_json::to_value(&none).unwrap();
+        assert!(json.get("retry_after").is_none(), "should skip None");
+
+        // A present hint serializes as a bare integer and survives a
+        // round-trip through the derived Serialize + custom Deserialize.
+        // (Deserialize always yields None — the header, not the body,
+        // is the source — so we only assert the serialized shape here.)
+        let some = AnthropicError::RateLimit {
+            message: "x".to_string(),
+            retry_after: Some(42),
+        };
+        let json = serde_json::to_value(&some).unwrap();
+        assert_eq!(json["retry_after"], 42);
+    }
+
+    #[cfg(feature = "client")]
+    #[test]
+    fn test_parse_retry_after_header() {
+        use reqwest::header::{HeaderMap, HeaderValue, RETRY_AFTER};
+
+        let mut headers = HeaderMap::new();
+        assert_eq!(parse_retry_after(&headers), None, "absent header");
+
+        headers.insert(RETRY_AFTER, HeaderValue::from_static("17"));
+        assert_eq!(parse_retry_after(&headers), Some(17));
+
+        // Surrounding whitespace is tolerated.
+        headers.insert(RETRY_AFTER, HeaderValue::from_static(" 8 "));
+        assert_eq!(parse_retry_after(&headers), Some(8));
+
+        // HTTP-date form (legal but unused by Anthropic) → None, no panic.
+        headers.insert(
+            RETRY_AFTER,
+            HeaderValue::from_static("Wed, 21 Oct 2026 07:28:00 GMT"),
+        );
+        assert_eq!(parse_retry_after(&headers), None);
     }
 
     // Test the Client
@@ -1282,11 +1473,7 @@ mod tests {
             .await
             .unwrap();
 
-        let msg: String = stream
-            .text()
-            .try_collect()
-            .await
-            .unwrap();
+        let msg: String = stream.text().try_collect().await.unwrap();
 
         assert_eq!(msg, "🙏");
     }

--- a/misanthropic/src/client.rs
+++ b/misanthropic/src/client.rs
@@ -44,21 +44,6 @@ pub struct Client {
     /// Encrypted API [`Key`] for convenience. It can be set to a new [`Key`] to
     /// change the key used for requests.
     pub key: Arc<Key>,
-    /// Rate limiter. Defaults to 50 requests per minute (tier 1).
-    #[cfg(feature = "rate-limiting")]
-    pub rate_limiter: Option<
-        Arc<
-            governor::RateLimiter<
-                governor::state::NotKeyed,
-                governor::state::InMemoryState,
-                governor::clock::DefaultClock,
-                governor::middleware::NoOpMiddleware,
-            >,
-        >,
-    >,
-    /// Rate limit jitter. Defaults to [`Self::DEFAULT_JITTER_MS`].
-    #[cfg(feature = "rate-limiting")]
-    pub jitter: Option<governor::Jitter>,
     /// Custom endpoint for the Messages API. Defaults to [`Self::MESSAGES_URL`].
     pub messages_url: Arc<Url>,
     /// Custom endpoint for the Batch API. Defaults to [`Self::BATCH_URL`].
@@ -91,9 +76,6 @@ impl Client {
     /// Default URL for the token counting API.
     pub const COUNT_TOKENS_URL: &'static str =
         "https://api.anthropic.com/v1/messages/count_tokens";
-    /// Default jitter in milliseconds for rate limiting (max).
-    #[cfg(feature = "rate-limiting")]
-    pub const DEFAULT_JITTER_MS: u64 = 20;
 
     /// Create a new [`Client`] from any type that can be converted into a
     /// [`Key`], like a [`String`] or a [`Vec`], but not a `&str`.
@@ -139,16 +121,6 @@ impl Client {
                 .build()
                 .unwrap(),
             key: Arc::new(key),
-            #[cfg(feature = "rate-limiting")]
-            rate_limiter: Some(Arc::new(governor::RateLimiter::direct(
-                governor::Quota::per_minute(
-                    std::num::NonZeroU32::new(50).unwrap(),
-                ),
-            ))),
-            #[cfg(feature = "rate-limiting")]
-            jitter: Some(governor::Jitter::up_to(
-                std::time::Duration::from_millis(Self::DEFAULT_JITTER_MS),
-            )),
             messages_url: Arc::new(Url::parse(Self::MESSAGES_URL).unwrap()),
             batch_url: Arc::new(Url::parse(Self::BATCH_URL).unwrap()),
             models_url: Arc::new(Url::parse(Self::MODELS_URL).unwrap()),
@@ -191,27 +163,8 @@ impl Client {
         Ok(self)
     }
 
-    /// Set [`Quota`] for the [`RateLimiter`].
-    ///
-    /// [`Quota`]: governor::Quota
-    /// [`RateLimiter`]: governor::RateLimiter
-    #[cfg(feature = "rate-limiting")]
-    pub fn set_rate_limit(&mut self, quota: governor::Quota) {
-        self.rate_limiter =
-            Some(Arc::new(governor::RateLimiter::direct(quota)));
-    }
-
-    /// Set [`Jitter`] for the [`RateLimiter`].
-    ///
-    /// [`Jitter`]: governor::Jitter
-    /// [`RateLimiter`]: governor::RateLimiter
-    #[cfg(feature = "rate-limiting")]
-    pub fn set_rate_limit_jitter(&mut self, jitter: governor::Jitter) {
-        self.jitter = Some(jitter);
-    }
-
     /// Create a [`reqwest::RequestBuilder`] with the API key set as a sensitive
-    /// header value. **Does not check rate limiting**.
+    /// header value.
     pub fn request_raw<U>(
         &self,
         method: reqwest::Method,
@@ -237,32 +190,12 @@ impl Client {
         self.inner.request(method, url).header("x-api-key", val)
     }
 
-    /// Await the rate limiter. It is not necessary to call this manually unless
-    /// you are doing something custom with [`request_raw`] or similar.
-    ///
-    /// [`request_raw`]: Self::request_raw
-    #[cfg(feature = "rate-limiting")]
-    pub async fn await_rate_limiter(&self) {
-        if let Some(limiter) = self.rate_limiter.as_ref() {
-            if let Some(jitter) = self.jitter {
-                limiter.until_ready_with_jitter(jitter).await;
-            } else {
-                limiter.until_ready().await;
-            }
-        }
-    }
-
     /// Send a GET request with the API key set as a sensitive header value.
     /// Returns a [`reqwest::Result`] for maximum flexibility.
     pub async fn get_raw<U>(&self, url: U) -> reqwest::Result<reqwest::Response>
     where
         U: reqwest::IntoUrl,
     {
-        #[cfg(feature = "rate-limiting")]
-        {
-            self.await_rate_limiter().await;
-        }
-
         #[cfg(feature = "log")]
         {
             log::debug!("GET:{}", url.as_str());
@@ -336,11 +269,6 @@ impl Client {
         B: serde::Serialize,
     {
         let url: reqwest::Url = url.into_url()?;
-
-        #[cfg(feature = "rate-limiting")]
-        {
-            self.await_rate_limiter().await;
-        }
 
         #[cfg(feature = "log")]
         {

--- a/misanthropic/src/stream.rs
+++ b/misanthropic/src/stream.rs
@@ -501,39 +501,15 @@ impl futures::Stream for Stream {
     }
 }
 
-/// Extension trait for our crate [`Event`] [`Stream`]s to filter out
-/// [`RateLimit`] and [`Overloaded`] [`AnthropicError`]s, as well as several
-/// other common use cases.
+/// Extension trait for our crate [`Event`] [`Stream`]s covering several common
+/// use cases such as extracting [`Delta`]s or [`text`] and assembling complete
+/// [`Message`]s in place.
 ///
-/// This is recommended for most use cases.
-///
-/// [`RateLimit`]: AnthropicError::RateLimit
-/// [`Overloaded`]: AnthropicError::Overloaded
+/// [`text`]: FilterExt::text
+/// [`Message`]: response::Message
 pub trait FilterExt:
     futures::stream::Stream<Item = Result<Event, Error>> + Sized + Send
 {
-    /// Filter out rate limit and overload errors. Because the server sends
-    /// these events there isn't a need to retry or backoff. The stream will
-    /// continue when ready.
-    ///
-    /// This is recommended for most use cases.
-    fn filter_rate_limit(
-        self,
-    ) -> impl futures::Stream<Item = Result<Event, Error>> + Send {
-        self.filter_map(|result| async move {
-            match result {
-                Ok(event) => Some(Ok(event)),
-                Err(Error::Anthropic {
-                    error:
-                        AnthropicError::Overloaded { .. }
-                        | AnthropicError::RateLimit { .. },
-                    ..
-                }) => None,
-                Err(error) => Some(Err(error)),
-            }
-        })
-    }
-
     /// Filter out everything but [`Event::ContentBlockDelta`]. This can include
     /// text, JSON, and tool use.
     fn deltas(
@@ -1067,12 +1043,7 @@ pub(crate) mod tests {
         // path in the `Stream` struct and every event type.
         let stream = mock_stream(include_str!("../test/data/sse.stream.txt"));
 
-        let text: String = stream
-            .filter_rate_limit()
-            .text()
-            .try_collect()
-            .await
-            .unwrap();
+        let text: String = stream.text().try_collect().await.unwrap();
 
         assert_eq!(
             text,
@@ -1102,12 +1073,7 @@ pub(crate) mod tests {
             mock_stream(include_str!("../test/data/thinking.sse.stream.txt"));
 
         // Test the text stream filters out the thinking delta.
-        let text: String = stream
-            .filter_rate_limit()
-            .text()
-            .try_collect()
-            .await
-            .unwrap();
+        let text: String = stream.text().try_collect().await.unwrap();
 
         assert_eq!(text, "27 * 453 = 12,231");
     }
@@ -1200,12 +1166,7 @@ pub(crate) mod tests {
         let stream = mock_stream_jsonl(JSON);
 
         // Test the text stream filters out the thinking delta.
-        let text: String = stream
-            .filter_rate_limit()
-            .text()
-            .try_collect()
-            .await
-            .unwrap();
+        let text: String = stream.text().try_collect().await.unwrap();
 
         assert_eq!(
             text,
@@ -1252,11 +1213,7 @@ pub(crate) mod tests {
 
         // In a real app you could RwLock the prompt and pass a reference, and
         // then append to the same prompt with `.write().await.extend(stream)`.
-        let stream = client
-            .stream(prompt.clone())
-            .await
-            .unwrap()
-            .filter_rate_limit();
+        let stream = client.stream(prompt.clone()).await.unwrap();
 
         pin_mut!(stream);
 

--- a/skills/misanthropic-message.md
+++ b/skills/misanthropic-message.md
@@ -23,7 +23,6 @@ tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 |------|---------|---------|
 | `client` | yes | Enables `Client` (HTTP). Disable for wasm data-only. |
 | `rustls-tls` | yes | Use rustls instead of system OpenSSL. |
-| `rate-limiting` | yes | Client-side rate limiting via `governor`. |
 | `prompt-caching` | no | Anthropic prompt-caching beta headers. |
 | `markdown` | no | `ToMarkdown` trait, markdown rendering. |
 | `image` / `png` / `jpeg` / `gif` / `webp` | no | Image support via the `image` crate. |


### PR DESCRIPTION
Closes #33.

Replaces the predictive client-side rate limiter with a reactive signal from the API, and removes a silent data-loss bug in the streaming path.

## Commits
1. **Remove `FilterExt::filter_rate_limit`** — it silently dropped terminal `Overloaded`/`RateLimit` errors. 429s happen on the initial POST (never reach the stream) and a mid-stream `overloaded_error` is a *terminal* SSE event the server doesn't resume after, so the filter only ever discarded errors the caller needed, yielding a truncated stream with no `MessageStop`. Terminal errors now propagate.
2. **Ignore local `.claude/` tooling dir** — incidental hygiene; a stray `scheduled_tasks.lock` had been committed previously.
3. **Drop `governor` predictive limiting** — the fixed 50 rpm guess couldn't account for tier, model, cache hits, or token counts. Removes the `rate-limiting` feature, the `governor` dep, `Client::{rate_limiter, jitter}`, `DEFAULT_JITTER_MS`, `set_rate_limit`, `set_rate_limit_jitter`, `await_rate_limiter`, and the limiter awaits in `get_raw`/`post_raw`.
4. **Surface `retry-after`** — parsed from the response header in `post`/`get` (before the body is consumed) and folded into the error. `AnthropicError::RateLimit` (429) and `Overloaded` (529) gain an optional `retry_after` seconds field; `AnthropicError::retry_after()` returns it as a `Duration` — the crate's signal that an error is retryable and for how long. HTTP-date form treated as absent (Anthropic sends seconds); skipped on serialize when absent.

A retry helper built on `retry_after()` will follow in a separate change.

## Breaking changes
- `rate-limiting` feature and all `governor`-based `Client` API removed.
- `FilterExt::filter_rate_limit` removed.
- `AnthropicError::{RateLimit, Overloaded}` gained a `retry_after` field.

## Verification
- `cargo fmt --all -- --check` clean
- `cargo test -p misanthropic --lib` — 226 pass
- `cargo test -p misanthropic --lib --no-default-features` — 194 pass
- wide-feature build + `chat-backend` check compile

Authored by Claude (Opus 4.8) via @mdegans's host; see `Co-Authored-By` trailers on each commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)