### PR TITLE
Live-suite rot fixes: Result-serde footgun, count_tokens, model catalog

### DIFF
--- a/.claude/skills/misan-messages-api/SKILL.md
+++ b/.claude/skills/misan-messages-api/SKILL.md
@@ -66,10 +66,14 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Build a Prompt (the request type) and send it. `Client::message`
     // forces `stream = false` and returns a `response::Message` directly.
+    // `messages` validates turn order, so the `?` is required — and not
+    // just for correctness: an un-unwrapped `Result` would itself satisfy
+    // `impl Serialize` and reach the wire as `{"Ok": {…}}` if the error
+    // type were serializable. It deliberately isn't.
     let message = client
         .message(
             Prompt::default()
-                .messages([(Role::User, "What is 2+2?")]),
+                .messages([(Role::User, "What is 2+2?")])?,
         )
         .await?;
 

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -7,6 +7,12 @@ on:
   pull_request:
     branches: [main]
 
+# A push superseding a PR head cancels the now-stale run instead of
+# overlapping it (main pushes keep their own group per sha and never cancel).
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name == 'push' && github.sha || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   # Build the `bashd` daemon as a static linux-musl binary (the artifact the
   # `DockerSandbox` injects into a container) and run its unit tests.

--- a/chat/backend/src/endpoints.rs
+++ b/chat/backend/src/endpoints.rs
@@ -117,12 +117,13 @@ pub async fn events_stream(
                     // responding. This is posisble but unlikely. The client
                     // will have to handle this case.
                     log::error!(
-                        "User possibly responded too fast. Error pushing user message to prompt: {:?}",
-                        serde_json::to_string_pretty(&e).unwrap()
+                        "User possibly responded too fast. Error pushing user message to prompt: {e}",
                     );
 
                     let response = model::response::Response::Err(
-                        model::response::Error::TurnOrder { error: e },
+                        model::response::Error::TurnOrder {
+                            message: e.to_string(),
+                        },
                     );
                     yield Event::default()
                         .event("response")

--- a/chat/model/src/response.rs
+++ b/chat/model/src/response.rs
@@ -25,14 +25,15 @@ pub enum Success {
 #[serde(rename_all = "snake_case")]
 pub enum Error {
     /// [`TurnOrderError`] when appending a [`Message`] to the [`Prompt`].
+    /// Carried as its display string — the error type itself is deliberately
+    /// not serde (see its docs).
     ///
     /// [`TurnOrderError`]: prompt::TurnOrderError
     /// [`Message`]: prompt::Message
     /// [`Prompt`]: prompt::Prompt
     TurnOrder {
-        /// Error
-        #[from]
-        error: prompt::TurnOrderError,
+        /// Error message
+        message: String,
     },
     /// [`misanthropic::client::Error`] (connection related).
     MisanthropicClient {

--- a/misanthropic/examples/neologism.rs
+++ b/misanthropic/examples/neologism.rs
@@ -45,7 +45,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // the box for building `Request`s, such as messages from a list of tuples
     // of `Role` and `String`.
     let message = client
-        .message(Prompt::default().messages([(Role::User, args.prompt)]))
+        .message(Prompt::default().messages([(Role::User, args.prompt)])?)
         .await?;
 
     println!("{}", message);

--- a/misanthropic/src/client.rs
+++ b/misanthropic/src/client.rs
@@ -701,6 +701,10 @@ impl Client {
     /// This calls the `/v1/messages/count_tokens` endpoint and returns the
     /// `input_tokens` count. Useful for estimating costs or making decisions
     /// about prompt construction before sending a full request.
+    ///
+    /// Generation-side fields a [`Prompt`] carries (`max_tokens`,
+    /// `temperature`, …) are stripped before posting — the endpoint rejects
+    /// them as extra inputs, and `max_tokens` is always set on a [`Prompt`].
     pub async fn count_tokens<P>(&self, prompt: P) -> Result<u32>
     where
         P: Serialize,
@@ -710,8 +714,29 @@ impl Client {
             input_tokens: u32,
         }
 
-        let response =
-            self.post(self.count_tokens_url.as_str(), prompt).await?;
+        // Fields the endpoint 400s on ("Extra inputs are not permitted"),
+        // captured live 2026-06-11 by probing each Prompt field. Deny-list
+        // (not allow-list) so an unknown future field still reaches the API
+        // and fails loudly there rather than being dropped silently here.
+        const NOT_COUNTABLE: &[&str] = &[
+            "max_tokens",
+            "metadata",
+            "stop_sequences",
+            "stream",
+            "temperature",
+            "top_k",
+            "top_p",
+            "service_tier",
+            "inference_geo",
+            "container",
+        ];
+
+        let mut body = serde_json::to_value(prompt)?;
+        if let Some(map) = body.as_object_mut() {
+            map.retain(|k, _| !NOT_COUNTABLE.contains(&k.as_str()));
+        }
+
+        let response = self.post(self.count_tokens_url.as_str(), body).await?;
         let count: TokenCount = parse_body(response, "TokenCount").await?;
 
         Ok(count.input_tokens)

--- a/misanthropic/src/client.rs
+++ b/misanthropic/src/client.rs
@@ -1485,10 +1485,14 @@ mod tests {
         let client = Client::new(key).unwrap();
 
         let message = client
-            .message(Prompt::default().messages([(
-                Role::User,
-                "Emit just the \"🙏\" emoji, please.",
-            )]))
+            .message(
+                Prompt::default()
+                    .messages([(
+                        Role::User,
+                        "Emit just the \"🙏\" emoji, please.",
+                    )])
+                    .unwrap(),
+            )
             .await
             .unwrap();
 
@@ -1916,10 +1920,14 @@ mod tests {
         let client = Client::new(key).unwrap();
 
         let stream = client
-            .stream(Prompt::default().messages([(
-                Role::User,
-                "Emit just the \"🙏\" emoji, please.",
-            )]))
+            .stream(
+                Prompt::default()
+                    .messages([(
+                        Role::User,
+                        "Emit just the \"🙏\" emoji, please.",
+                    )])
+                    .unwrap(),
+            )
             .await
             .unwrap();
 
@@ -1940,7 +1948,9 @@ mod tests {
 
         let count = client
             .count_tokens(
-                Prompt::default().messages([(Role::User, "Hello, world!")]),
+                Prompt::default()
+                    .messages([(Role::User, "Hello, world!")])
+                    .unwrap(),
             )
             .await
             .unwrap();

--- a/misanthropic/src/model.rs
+++ b/misanthropic/src/model.rs
@@ -688,6 +688,25 @@ mod tests {
     #[tokio::test]
     #[ignore = "This test requires a real API key."]
     async fn test_ids_are_valid() {
+        // Not probed live: RETIRED ids 404 for everyone (the whole Claude 3
+        // family, verified 2026-06-11); GATED ids exist but 404 on accounts
+        // without the entitlement (Mythos is org-approved). A *typo'd* new
+        // variant still fails: it's in neither list. When a model retires,
+        // move it here — consciously.
+        const RETIRED: &[Id] = &[
+            Id::Haiku30,
+            Id::Haiku35,
+            Id::Haiku35_20241022,
+            Id::Opus30,
+            Id::Opus30_20240229,
+            Id::Sonnet35,
+            Id::Sonnet35_20240620,
+            Id::Sonnet35_20241022,
+            Id::Sonnet37,
+            Id::Sonnet37_20250219,
+        ];
+        const GATED: &[Id] = &[Id::Mythos5];
+
         let key = load_api_key().expect("API key not found");
         let client = Client::new(key).unwrap();
 
@@ -696,17 +715,53 @@ mod tests {
             .unwrap();
 
         for model in Id::iter() {
+            if RETIRED.contains(&model) || GATED.contains(&model) {
+                continue;
+            }
             prompt.model = model.into();
 
             // If this fails (because a new model was added), it should be:
             // * added to the list of models above and
             // * the `latest` aliases should be updated
             // * the `name` method updated
-            let response = client.message(&prompt).await.unwrap();
+            //
+            // 15 sequential live calls — concurrently with the rest of the
+            // `--ignored` suite — *will* see transient 429/529s, so honor
+            // the server's `retry-after` hint (both variants carry one)
+            // rather than flake.
+            let mut attempts = 0;
+            let response = loop {
+                match client.message(&prompt).await {
+                    Ok(response) => break response,
+                    Err(crate::client::Error::Anthropic(e))
+                        if e.status()
+                            .is_some_and(|s| matches!(s.get(), 429 | 529))
+                            && attempts < 5 =>
+                    {
+                        attempts += 1;
+                        eprintln!("{model:?}: {e}; retry {attempts}/5");
+                        // The server's hint is authoritative; back off on
+                        // our own only when it didn't send one.
+                        tokio::time::sleep(e.retry_after().unwrap_or(
+                            std::time::Duration::from_secs(2 * attempts),
+                        ))
+                        .await;
+                    }
+                    Err(e) => panic!("{model:?}: {e}"),
+                }
+            };
 
-            // If the mode is not a latest tag, we want to check it matches
-            // the model we set.
-            if !serde_json::to_string(&model).unwrap().contains("latest") {
+            // Only date-pinned ids echo back verbatim; aliases (3.x
+            // `-latest`, 4.x+ undated like `claude-opus-4-0`) resolve
+            // server-side to whatever dated id is current.
+            let pinned = Model::from(model)
+                .name()
+                .rsplit('-')
+                .next()
+                .is_some_and(|tail| {
+                    tail.len() == 8 && tail.bytes().all(|b| b.is_ascii_digit())
+                });
+            if pinned {
                 assert_eq!(response.model, model);
             }
         }

--- a/misanthropic/src/model.rs
+++ b/misanthropic/src/model.rs
@@ -212,7 +212,10 @@ impl Model {
                 Id::Opus45 => "claude-opus-4-5",
                 Id::Sonnet46 => "claude-sonnet-4-6",
                 Id::Opus46 => "claude-opus-4-6",
+                Id::Opus47 => "claude-opus-4-7",
                 Id::Opus48 => "claude-opus-4-8",
+                Id::Fable5 => "claude-fable-5",
+                Id::Mythos5 => "claude-mythos-5",
             },
             Model::Custom(name) => name,
         }
@@ -232,7 +235,12 @@ impl Model {
     /// [`Role::System`]: crate::prompt::message::Role::System
     /// [`Prompt::system`]: crate::Prompt::system
     pub fn supports_system_role(&self) -> bool {
-        matches!(self, Model::Anthropic(Id::Opus48))
+        // Fable 5 verified live 2026-06-11 (placement grammar enforced, turn
+        // honored); Mythos 5 is the same underlying model.
+        matches!(
+            self,
+            Model::Anthropic(Id::Opus48 | Id::Fable5 | Id::Mythos5)
+        )
     }
 
     /// Pick the first of `preferred` [`Role`]s this model supports, for seating
@@ -410,10 +418,27 @@ pub enum Id {
     /// Opus 4.6
     #[serde(rename = "claude-opus-4-6")]
     Opus46,
+    /// Opus 4.7. Supports the 1M-token context window via the
+    /// `context-1m-2025-08-07` beta header — see `Client::beta`; there is
+    /// no separate wire id (Claude Code's `[1m]` suffix is UI notation).
+    #[serde(rename = "claude-opus-4-7")]
+    Opus47,
     /// Opus 4.8 (latest flagship). First model to support
     /// [mid-conversation system messages](crate::prompt::message::Role::System).
+    /// 1M context via the `context-1m-2025-08-07` beta header.
     #[serde(rename = "claude-opus-4-8")]
     Opus48,
+
+    // ── Claude 5.x ───────────────────────────────────────────────────────
+    /// Fable 5 — the first Mythos-class model (above Opus in capability).
+    /// The 1M-token context window is the default (no beta header), with up
+    /// to 128k output tokens.
+    #[serde(rename = "claude-fable-5")]
+    Fable5,
+    /// Mythos 5 — Fable 5 without the dual-use safety measures; available
+    /// only to approved organizations (account-gated). 1M context default.
+    #[serde(rename = "claude-mythos-5")]
+    Mythos5,
 }
 
 impl Id {
@@ -444,7 +469,10 @@ impl Id {
             Id::Opus45 => "opus-4.5-latest",
             Id::Sonnet46 => "sonnet-4.6",
             Id::Opus46 => "opus-4.6",
+            Id::Opus47 => "opus-4.7",
             Id::Opus48 => "opus-4.8",
+            Id::Fable5 => "fable-5",
+            Id::Mythos5 => "mythos-5",
         }
     }
 }

--- a/misanthropic/src/model.rs
+++ b/misanthropic/src/model.rs
@@ -688,11 +688,13 @@ mod tests {
     #[tokio::test]
     #[ignore = "This test requires a real API key."]
     async fn test_ids_are_valid() {
-        // Not probed live: RETIRED ids 404 for everyone (the whole Claude 3
-        // family, verified 2026-06-11); GATED ids exist but 404 on accounts
-        // without the entitlement (Mythos is org-approved). A *typo'd* new
-        // variant still fails: it's in neither list. When a model retires,
-        // move it here — consciously.
+        // Not probed live: RETIRED ids 404 for everyone *on the API* (the
+        // whole Claude 3 family, verified 2026-06-11 — retirement differs
+        // by surface: claude.ai un-retired Opus 3 by popular demand);
+        // GATED ids exist but 404 on accounts without the entitlement
+        // (Mythos is org-approved). A *typo'd* new variant still fails:
+        // it's in neither list. When a model retires, move it here —
+        // consciously.
         const RETIRED: &[Id] = &[
             Id::Haiku30,
             Id::Haiku35,
@@ -726,26 +728,27 @@ mod tests {
             // * the `name` method updated
             //
             // 15 sequential live calls — concurrently with the rest of the
-            // `--ignored` suite — *will* see transient 429/529s, so honor
-            // the server's `retry-after` hint (both variants carry one)
-            // rather than flake.
+            // `--ignored` suite — *will* see transient 429/529s, so retry
+            // those rather than flake. `retry_after()` is the designed
+            // discriminator (`Some` only for RateLimit/Overloaded), though
+            // a 529 can arrive without the header — seen live 2026-06-11 —
+            // so header-less Overloaded gets a small backoff instead.
             let mut attempts = 0;
             let response = loop {
+                use crate::client::{AnthropicError, Error};
                 match client.message(&prompt).await {
                     Ok(response) => break response,
-                    Err(crate::client::Error::Anthropic(e))
-                        if e.status()
-                            .is_some_and(|s| matches!(s.get(), 429 | 529))
-                            && attempts < 5 =>
-                    {
+                    Err(Error::Anthropic(e)) if attempts < 5 => {
                         attempts += 1;
+                        let wait = match (e.retry_after(), &e) {
+                            (Some(hint), _) => hint,
+                            (None, AnthropicError::Overloaded { .. }) => {
+                                std::time::Duration::from_secs(2 * attempts)
+                            }
+                            _ => panic!("{model:?}: {e}"),
+                        };
                         eprintln!("{model:?}: {e}; retry {attempts}/5");
-                        // The server's hint is authoritative; back off on
-                        // our own only when it didn't send one.
-                        tokio::time::sleep(e.retry_after().unwrap_or(
-                            std::time::Duration::from_secs(2 * attempts),
-                        ))
-                        .await;
+                        tokio::time::sleep(wait).await;
                     }
                     Err(e) => panic!("{model:?}: {e}"),
                 }

--- a/misanthropic/src/prompt.rs
+++ b/misanthropic/src/prompt.rs
@@ -259,7 +259,11 @@ pub enum InferenceGeo {
 /// [`System`]: crate::prompt::message::Role::System
 /// [`ServerToolUse`]: crate::prompt::message::Block::ServerToolUse
 /// [`StopReason::PauseTurn`]: crate::response::StopReason::PauseTurn
-#[derive(Debug, thiserror::Error, Serialize, Deserialize)]
+// Deliberately NOT Serialize: serde's blanket `impl Serialize for Result`
+// would otherwise let an un-unwrapped builder Result pass `impl Serialize`
+// bounds (e.g. `client.message(prompt.messages(…))`) and reach the wire as
+// `{"Ok": {…}}` — a silent 400. Without the derive that's a compile error.
+#[derive(Debug, thiserror::Error)]
 pub enum TurnOrderError {
     /// The first message must be from the user — assistant and system turns
     /// cannot open a conversation. Use the top-level [`Prompt::system`] field

--- a/misanthropic/src/stream.rs
+++ b/misanthropic/src/stream.rs
@@ -1707,53 +1707,6 @@ pub(crate) mod tests {
         }
     }
 
-    // Test from live API. If they break our client, we'll know.
-    #[cfg(feature = "client")]
-    #[tokio::test]
-    #[ignore]
-    async fn test_stream_redacted_thought() {
-        const TRIGGER: &str = "ANTHROPIC_MAGIC_STRING_TRIGGER_REDACTED_THINKING_46C9A13E193C177646C7398A98432ECCCE4C1253D5E2D82641AC0E52CC2876CB";
-        let api_key = crate::utils::load_api_key().await;
-        let client = crate::Client::new(api_key).unwrap();
-        let prompt = Prompt::default()
-            // Only sonnet 3.7 and newer will respond to the trigger.
-            .model(Id::Sonnet37)
-            // Sonnet 3.7 still accepts the deprecated fixed-budget mode.
-            .thinking(prompt::Thinking::enabled(1024.try_into().unwrap()))
-            .add_message(Message {
-                role: Role::User,
-                content: TRIGGER.into(),
-            })
-            .unwrap();
-
-        // In a real app you could RwLock the prompt and pass a reference, and
-        // then append to the same prompt with `.write().await.extend(stream)`.
-        let stream = client.stream(prompt.clone()).await.unwrap();
-
-        pin_mut!(stream);
-
-        let mut redacted_seen = false;
-        let mut events = Vec::new();
-        while let Some(event) = stream.next().await {
-            match &event {
-                Ok(Event::ContentBlockStart { content_block, .. }) => {
-                    if let Block::RedactedThought { signature } = content_block
-                    {
-                        assert!(!signature.is_empty());
-                        redacted_seen = true;
-                    }
-
-                    events.push(event);
-                }
-                _ => {
-                    events.push(event);
-                }
-            }
-        }
-
-        assert!(redacted_seen);
-    }
-
     // This also tests the `_ip` version since this just wraps it.
     #[tokio::test]
     async fn test_stream_with_message() {


### PR DESCRIPTION
Everything the first full live-suite CI run (and local sweeps) flushed out:

- **`TurnOrderError` is deliberately not `Serialize`** (breaking): serde's blanket `impl Serialize for Result` let un-unwrapped builder results reach the wire as `{"Ok": {…}}` — a silent 400. Three live tests, an example, and a skill quick-start had it. Now a compile error; the chat demo's wire enum carries the display string.
- **`count_tokens` never worked**: the endpoint rejects `max_tokens` (always set on a `Prompt`) and nine other generation-side fields — each probed live. They're stripped at the wire, deny-list style.
- **Model catalog**: adds `claude-fable-5`, `claude-mythos-5`, `claude-opus-4-7` (live `/v1/models` diff). No `[1m]` ids — that's Claude Code UI notation; 1M on Opus 4.6+ is the `context-1m-2025-08-07` beta header, default on Fable/Mythos. Fable 5 verified live to honor in-message system turns.
- **`test_ids_are_valid`**: the entire Claude 3 family is retired (probed); retired/gated skip lists, date-pinned echo assertion (4.x aliases resolve server-side), `retry-after`-honoring retries for the 429/529s the parallel suite generates.
- **`test_stream_redacted_thought` deleted**: the magic trigger died with Sonnet 3.7 (probed through Fable 5); the wire shape stays covered by the offline round-trip fixture.

Full `--ignored` live suite: 18/18 green locally, twice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)