### PR TITLE
Validate tool_use → tool_result adjacency client-side (#102)

### DIFF
--- a/.claude/skills/misan-messages-api/SKILL.md
+++ b/.claude/skills/misan-messages-api/SKILL.md
@@ -751,7 +751,10 @@ your task — they're the most current, compiler-checked usage.
   resume by appending the paused turn back. Note Anthropic itself **no longer
   enforces** strict alternation server-side, but many Anthropic-compatible
   backends still do, so the crate keeps the check (in `prompt.rs`,
-  `check_turn_order` / `Message::may_precede`).
+  `check_turn_order` / `Message::may_precede`). Tool blocks are checked too:
+  `tool_result`s must **lead** their user turn, and every client `tool_use`
+  must be answered by a matching `tool_result` in the next turn — otherwise
+  `TurnOrderError::ToolResultNotLeading` / `UnansweredToolUse`.
 - **Owned data, no lifetimes** — public types own their string data
   (`Cow<'static, str>` under the hood, sanitized when `langsan` is on) and
   carry **no lifetime parameter**. You can freely store a `Use`/`Message`/etc.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,24 @@ record; this file aggregates them.
   fields non-breaking (it already grew `strict`, `defer_loading`,
   `allowed_callers`). No `Default` is derived, deliberately: an empty-schema
   default is an invalid tool (#106).
+- **`prompt::TurnOrderError` is `#[non_exhaustive]`.** Downstream `match` on it
+  now needs a `_` arm. The wire turn-order grammar keeps growing (and shrinking
+  — Anthropic relaxes rules too), so adding a variant must stay non-breaking
+  (#102).
+
+### Added
+
+- **Client-side `tool_use`/`tool_result` adjacency validation** (#102).
+  `Prompt` turn-order validation now models two more wire rules as constructive
+  [`TurnOrderError`]s instead of deferring to a server 400:
+  - `ToolResultNotLeading` — a turn's `tool_result` blocks must form a leading
+    run (`[tool_result, text]` is accepted; `[text, tool_result]` is a 400).
+  - `UnansweredToolUse` — every client `tool_use` must be answered by a matching
+    leading `tool_result` in the immediately following user turn; the error
+    names the unanswered ids. `server_tool_use` is excluded — the API answers
+    those itself.
+
+  [`TurnOrderError`]: https://docs.rs/misanthropic/latest/misanthropic/prompt/enum.TurnOrderError.html
 
 ### Documentation
 

--- a/misanthropic/src/prompt.rs
+++ b/misanthropic/src/prompt.rs
@@ -263,7 +263,11 @@ pub enum InferenceGeo {
 // would otherwise let an un-unwrapped builder Result pass `impl Serialize`
 // bounds (e.g. `client.message(prompt.messages(…))`) and reach the wire as
 // `{"Ok": {…}}` — a silent 400. Without the derive that's a compile error.
+// `#[non_exhaustive]`: the wire turn-order grammar keeps growing (the tool
+// adjacency rules in #102 were the latest), so adding a variant must stay a
+// non-breaking change. Downstream `match` needs a `_` arm.
 #[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
 pub enum TurnOrderError {
     /// The first message must be from the user — assistant and system turns
     /// cannot open a conversation. Use the top-level [`Prompt::system`] field

--- a/misanthropic/src/prompt.rs
+++ b/misanthropic/src/prompt.rs
@@ -289,6 +289,33 @@ pub enum TurnOrderError {
         /// The message that may not follow it.
         second: Message,
     },
+    /// A turn places a [`ToolResult`] after non-result content. The wire
+    /// requires `tool_result` blocks to *lead* their (user) message — a
+    /// contiguous leading run. `[text, tool_result]` is a 400; `[tool_result,
+    /// text]` is accepted (verified live, 2026-06-12).
+    ///
+    /// [`ToolResult`]: crate::prompt::message::Block::ToolResult
+    #[error("tool_result blocks must lead their message, but a {} turn places one after other content", .message.role)]
+    ToolResultNotLeading {
+        /// The offending message.
+        message: Message,
+    },
+    /// An [`Assistant`] turn emitted client [`ToolUse`] blocks the immediately
+    /// following user turn does not answer: each client `tool_use` must have a
+    /// matching leading [`ToolResult`] (by [`tool_use_id`]) in the next
+    /// message.
+    ///
+    /// [`Assistant`]: crate::prompt::message::Role::Assistant
+    /// [`ToolUse`]: crate::prompt::message::Block::ToolUse
+    /// [`ToolResult`]: crate::prompt::message::Block::ToolResult
+    /// [`tool_use_id`]: crate::tool::Result::tool_use_id
+    #[error("{} client tool_use block(s) were not answered by the next turn: {}", .unanswered.len(), .unanswered.join(", "))]
+    UnansweredToolUse {
+        /// The assistant message whose `tool_use` blocks went unanswered.
+        message: Message,
+        /// The `tool_use` ids with no matching leading `tool_result` next.
+        unanswered: Vec<String>,
+    },
 }
 static_assertions::assert_impl_all!(TurnOrderError: Send, Sync);
 
@@ -397,15 +424,26 @@ impl Prompt {
                 message: first.clone(),
             });
         }
+        for message in &self.messages {
+            Self::check_results_lead(message)?;
+        }
         for pair in self.messages.windows(2) {
-            if !pair[0].may_precede(&pair[1]) {
-                return Err(TurnOrderError::BadTransition {
-                    first: pair[0].clone(),
-                    second: pair[1].clone(),
-                });
-            }
+            pair[0].may_precede(&pair[1])?;
         }
         Ok(())
+    }
+
+    /// A turn's [`ToolResult`](message::Block::ToolResult) blocks must lead
+    /// (the within-message half of #102; the pairwise half lives in
+    /// [`Message::may_precede`]).
+    fn check_results_lead(message: &Message) -> Result<(), TurnOrderError> {
+        if message.results_lead() {
+            Ok(())
+        } else {
+            Err(TurnOrderError::ToolResultNotLeading {
+                message: message.clone(),
+            })
+        }
     }
 
     /// Add a [`Message`] to [`messages`]. When adding multiple messages, use
@@ -445,14 +483,10 @@ impl Prompt {
         M: Into<Message>,
     {
         let message: Message = message.into();
+        Self::check_results_lead(&message)?;
         match self.messages.last() {
             Some(last) => {
-                if !last.may_precede(&message) {
-                    return Err(TurnOrderError::BadTransition {
-                        first: last.clone(),
-                        second: message.clone(),
-                    });
-                }
+                last.may_precede(&message)?;
             }
             None => {
                 // The first message must be a user message.
@@ -1980,6 +2014,124 @@ mod tests {
             .add_message((Role::Assistant, "hello again"))
             .unwrap_err();
         assert!(matches!(err, TurnOrderError::BadTransition { .. }));
+    }
+
+    #[test]
+    fn test_tool_result_must_lead_user_turn() {
+        // The wire requires `tool_result` blocks to lead their user message
+        // (#102). `[result, text]` is accepted; `[text, result]` is a 400.
+        use crate::prompt::message::{Block, Content};
+
+        let tool_use: Block = serde_json::from_value(serde_json::json!({
+            "type": "tool_use", "id": "toolu_1", "name": "get_time", "input": {}
+        }))
+        .unwrap();
+        let result: Block = serde_json::from_value(serde_json::json!({
+            "type": "tool_result", "tool_use_id": "toolu_1", "content": "12:00"
+        }))
+        .unwrap();
+        let text = Block::text("here you go");
+
+        let head = || {
+            Prompt::default()
+                .add_message((Role::User, "what time is it?"))
+                .unwrap()
+                .add_message((Role::Assistant, Content(vec![tool_use.clone()])))
+                .unwrap()
+        };
+
+        // Results lead → accepted.
+        head()
+            .add_message((
+                Role::User,
+                Content(vec![result.clone(), text.clone()]),
+            ))
+            .unwrap();
+
+        // A result trailing other content → rejected.
+        let err = head()
+            .add_message((Role::User, Content(vec![text, result])))
+            .unwrap_err();
+        assert!(matches!(err, TurnOrderError::ToolResultNotLeading { .. }));
+    }
+
+    #[test]
+    fn test_client_tool_use_must_be_answered() {
+        // A client `tool_use` must be answered by a matching leading
+        // `tool_result` in the immediately following user turn (#102).
+        use crate::prompt::message::{Block, Content};
+
+        let mk_use = |id: &str| -> Block {
+            serde_json::from_value(serde_json::json!({
+                "type": "tool_use", "id": id, "name": "get_time", "input": {}
+            }))
+            .unwrap()
+        };
+        let mk_result = |id: &str| -> Block {
+            serde_json::from_value(serde_json::json!({
+                "type": "tool_result", "tool_use_id": id, "content": "ok"
+            }))
+            .unwrap()
+        };
+
+        // Answered → accepted.
+        Prompt::default()
+            .add_message((Role::User, "go"))
+            .unwrap()
+            .add_message((Role::Assistant, Content(vec![mk_use("toolu_1")])))
+            .unwrap()
+            .add_message((Role::User, Content(vec![mk_result("toolu_1")])))
+            .unwrap();
+
+        // A plain-text user turn answers nothing → rejected.
+        let err = Prompt::default()
+            .add_message((Role::User, "go"))
+            .unwrap()
+            .add_message((Role::Assistant, Content(vec![mk_use("toolu_1")])))
+            .unwrap()
+            .add_message((Role::User, "no results here"))
+            .unwrap_err();
+        assert!(matches!(err, TurnOrderError::UnansweredToolUse { .. }));
+
+        // Partial coverage → the error names the unanswered id.
+        let err = Prompt::default()
+            .add_message((Role::User, "go"))
+            .unwrap()
+            .add_message((
+                Role::Assistant,
+                Content(vec![mk_use("toolu_1"), mk_use("toolu_2")]),
+            ))
+            .unwrap()
+            .add_message((Role::User, Content(vec![mk_result("toolu_1")])))
+            .unwrap_err();
+        match err {
+            TurnOrderError::UnansweredToolUse { unanswered, .. } => {
+                assert_eq!(unanswered, vec!["toolu_2".to_string()]);
+            }
+            other => panic!("expected UnansweredToolUse, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_trailing_client_tool_use_is_allowed() {
+        // An assistant `tool_use` as the *last* turn has no following turn to
+        // answer it, so the pairwise rule does not fire. (Whether a trailing
+        // unanswered `tool_use` is itself a wire error is a separate, as-yet
+        // unverified question — see the #102 live probe.)
+        use crate::prompt::message::{Block, Content};
+
+        let tool_use: Block = serde_json::from_value(serde_json::json!({
+            "type": "tool_use", "id": "toolu_1", "name": "get_time", "input": {}
+        }))
+        .unwrap();
+
+        Prompt::default()
+            .add_message((Role::User, "go"))
+            .unwrap()
+            .add_message((Role::Assistant, Content(vec![tool_use])))
+            .unwrap()
+            .check_turn_order()
+            .unwrap();
     }
 
     #[test]

--- a/misanthropic/src/prompt/message.rs
+++ b/misanthropic/src/prompt/message.rs
@@ -355,28 +355,44 @@ where
 }
 
 impl Message {
-    /// Whether this turn may be immediately followed by `next` in the
-    /// `messages` array.
+    /// Validate that this turn may be immediately followed by `next` in the
+    /// `messages` array, returning the specific [`TurnOrderError`] on the
+    /// first violation. (There is no `bool` coercion in Rust — call
+    /// [`is_ok`](Result::is_ok) for a predicate, or `?` to propagate.)
     ///
-    /// Encodes the user/assistant alternation plus the placement rules for a
-    /// mid-conversation [`System`](Role::System) turn, with two
-    /// content-sensitive exceptions on an [`Assistant`](Role::Assistant)
-    /// tail:
+    /// Enforces, in order:
     ///
-    /// - two adjacent `Assistant` turns are allowed when the first carries a
-    ///   [`ServerToolUse`](Block::ServerToolUse) block (a paused turn and its
-    ///   continuation) — see [`TurnOrderError`] for the rationale;
-    /// - `Assistant` → `System` is allowed when the first
-    ///   [ends in a server-tool *result*](Self::ends_in_server_tool_result).
-    ///   This is the **wire** rule, verified live against the validator
-    ///   (2026-06-12, pinned by the `count_tokens` placement probes): the
-    ///   docs' "ending in server tool use" is wrong, so a *paused* turn
-    ///   (ending in the in-flight use) is **not** a legal predecessor.
+    /// - the user/assistant role alternation plus the mid-conversation
+    ///   [`System`](Role::System) placement rules, with two content-sensitive
+    ///   exceptions on an [`Assistant`](Role::Assistant) tail — a
+    ///   [`BadTransition`] otherwise:
+    ///   - two adjacent `Assistant` turns when the first carries a
+    ///     [`ServerToolUse`](Block::ServerToolUse) block (a paused turn and its
+    ///     continuation);
+    ///   - `Assistant` → `System` when the first
+    ///     [ends in a server-tool *result*](Self::ends_in_server_tool_result).
+    ///     This is the **wire** rule, verified live against the validator
+    ///     (2026-06-12, pinned by the `count_tokens` placement probes): the
+    ///     docs' "ending in server tool use" is wrong, so a *paused* turn
+    ///     (ending in the in-flight use) is **not** a legal predecessor.
+    /// - every client [`ToolUse`](Block::ToolUse) in this turn is answered by
+    ///   a matching leading [`ToolResult`](Block::ToolResult) in `next` — an
+    ///   [`UnansweredToolUse`] otherwise (#102).
+    ///
+    /// The within-message "results lead" rule is *not* pairwise and is checked
+    /// per message by [`Prompt::check_turn_order`](crate::Prompt::check_turn_order).
     ///
     /// [`TurnOrderError`]: crate::prompt::TurnOrderError
-    pub(crate) fn may_precede(&self, next: &Self) -> bool {
+    /// [`BadTransition`]: crate::prompt::TurnOrderError::BadTransition
+    /// [`UnansweredToolUse`]: crate::prompt::TurnOrderError::UnansweredToolUse
+    pub(crate) fn may_precede(
+        &self,
+        next: &Self,
+    ) -> Result<(), crate::prompt::TurnOrderError> {
+        use crate::prompt::TurnOrderError;
         use Role::{Assistant, System, User};
-        matches!(
+
+        let role_ok = matches!(
             (self.role, next.role),
             (User, Assistant)
                 | (Assistant, User)
@@ -387,7 +403,74 @@ impl Message {
             && self.has_server_tool_use())
             || (self.role == Assistant
                 && next.role == System
-                && self.ends_in_server_tool_result())
+                && self.ends_in_server_tool_result());
+        if !role_ok {
+            return Err(TurnOrderError::BadTransition {
+                first: self.clone(),
+                second: next.clone(),
+            });
+        }
+
+        // Every client `tool_use` must be answered by a matching leading
+        // `tool_result` in `next`. A no-op unless this turn carries client
+        // tool-use blocks (so it never fires on plain turns or a
+        // `server_tool_use` tail — the API answers those itself).
+        let answered: std::collections::BTreeSet<&str> =
+            next.leading_tool_result_ids().collect();
+        let unanswered: Vec<String> = self
+            .client_tool_use_ids()
+            .filter(|id| !answered.contains(id))
+            .map(String::from)
+            .collect();
+        if !unanswered.is_empty() {
+            return Err(TurnOrderError::UnansweredToolUse {
+                message: self.clone(),
+                unanswered,
+            });
+        }
+
+        Ok(())
+    }
+
+    /// Whether every [`Block::ToolResult`] in this turn *leads* — i.e. the
+    /// results form a contiguous prefix, with no result after a non-result
+    /// block. The wire requires `tool_result` blocks to lead their user
+    /// message (`[text, tool_result]` is a 400; `[tool_result, text]` is
+    /// accepted). Trivially true for content with no results.
+    pub(crate) fn results_lead(&self) -> bool {
+        match self.content.iter().position(|b| !b.is_tool_result()) {
+            Some(first_non_result) => !self.content[first_non_result..]
+                .iter()
+                .any(Block::is_tool_result),
+            None => true,
+        }
+    }
+
+    /// Ids of the *client* [`Block::ToolUse`] calls in this turn — the ones
+    /// the caller must answer with a `tool_result` in the next turn.
+    /// [`ServerToolUse`](Block::ServerToolUse) is excluded: the API answers
+    /// those itself.
+    pub(crate) fn client_tool_use_ids(&self) -> impl Iterator<Item = &str> {
+        self.content.iter().filter_map(|b| match b {
+            Block::ToolUse { call } => Some(call.id.as_ref()),
+            _ => None,
+        })
+    }
+
+    /// Ids answered by the *leading* run of [`Block::ToolResult`] blocks (the
+    /// `tool_use_id` each carries). Only the leading run counts — a result
+    /// that does not lead is itself a [`results_lead`](Self::results_lead)
+    /// violation.
+    pub(crate) fn leading_tool_result_ids(&self) -> impl Iterator<Item = &str> {
+        self.content
+            .iter()
+            .take_while(|b| b.is_tool_result())
+            .filter_map(|b| match b {
+                Block::ToolResult { result } => {
+                    Some(result.tool_use_id.as_ref())
+                }
+                _ => None,
+            })
     }
 }
 


### PR DESCRIPTION
Closes #102 (rules 1 & 2; rule 3 deferred — see below).

Surfaces two of the three wire rules pinned by the `count_tokens` placement probes as constructive `TurnOrderError`s, so a malformed prompt fails with a local, specific error instead of an opaque server 400:

- **`ToolResultNotLeading`** — a turn's `tool_result` blocks must form a leading run (`[tool_result, text]` accepted; `[text, tool_result]` is a 400). A *within-message* invariant, checked per message.
- **`UnansweredToolUse { unanswered }`** — every client `tool_use` must be answered by a matching leading `tool_result` in the immediately following user turn; the error names the unanswered ids. `server_tool_use` is excluded — the API answers those itself.

## Notable changes

- `Message::may_precede` now returns `Result<(), TurnOrderError>` instead of `bool`, folding the pairwise tool-use coverage check in alongside the existing role grammar so each transition reports its own specific error. The "results lead" rule isn't pairwise, so it stays a separate per-message pass. (`may_precede` is `pub(crate)`, so this isn't a public break.)
- **`TurnOrderError` is now `#[non_exhaustive]`** — the wire grammar keeps changing (Anthropic adds *and* relaxes rules), so variant additions must stay non-breaking. Downstream `match` needs a `_` arm.
- CHANGELOG + `misan-messages-api` skill turn-order notes updated.

## Deliberately deferred

- **Rule 3** (a dangling `server_tool_use` may only be the last message). The `#[ignore]`d probe already pins the paused→user case (`without a corresponding`), but our validator's existing `has_server_tool_use` exception (and its pinned test) allow paused→assistant, which isn't directly probed. Settling that needs a live `count_tokens` run, so rule 3 waits for a capture-enabled session. Shipping without it is a non-regression: the validator stays *as lenient as before* for that one shape.
- A *trailing* unanswered client `tool_use` (no following turn) is left alone — whether that's itself a wire error is a separate, unverified question.

## Verification

Offline gate green: fmt, clippy (`--all-features --all-targets`), `RUSTDOCFLAGS=-D warnings` doc, and tests on `--all-features` + `--no-default-features`, including the `__skills` doctests. New offline tests cover both rules and the trailing-tool_use allowance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Pwq7cZZ8egm1gdrbuYcVB4)_