### PR TITLE
Make Models constructible for mocking + test/CI fixes (alpha.6)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -519,7 +519,7 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bashd"
-version = "1.0.0-alpha.5"
+version = "1.0.0-alpha.6"
 dependencies = [
  "async-stream",
  "axum 0.8.9",
@@ -3278,7 +3278,7 @@ dependencies = [
 
 [[package]]
 name = "misanthropic"
-version = "1.0.0-alpha.5"
+version = "1.0.0-alpha.6"
 dependencies = [
  "arboard",
  "async-stream",
@@ -3324,7 +3324,7 @@ dependencies = [
 
 [[package]]
 name = "misanthropic-derive"
-version = "1.0.0-alpha.5"
+version = "1.0.0-alpha.6"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 # Shared package metadata. Members opt in per-field with `version.workspace =
 # true` etc., so the version lives in exactly one place.
 [workspace.package]
-version = "1.0.0-alpha.5"
+version = "1.0.0-alpha.6"
 edition = "2024"
 authors = ["Michael de Gans <michael.john.degans@gmail.com>"]
 homepage = "https://github.com/mdegans/misanthropic"
@@ -26,7 +26,7 @@ rust.missing_docs = "deny"
 # Shared dependency declarations. The inter-crate version/path is defined once
 # here; members use `misanthropic-derive = { workspace = true }`.
 [workspace.dependencies]
-misanthropic-derive = { version = "1.0.0-alpha.5", path = "misanthropic-derive" }
+misanthropic-derive = { version = "1.0.0-alpha.6", path = "misanthropic-derive" }
 
 [profile.release]
 lto = true

--- a/misanthropic/src/client.rs
+++ b/misanthropic/src/client.rs
@@ -1748,7 +1748,11 @@ mod tests {
             .model(crate::Id::Haiku45)
             .add_message((
                 Role::User,
-                "Search anthropic.com and name one product Anthropic makes. \
+                // No "search anthropic.com": `allowed_domains` is a server-side
+                // result filter the model can't see, so naming a domain in the
+                // prompt makes it decline a restriction it can't express (#117).
+                // The filter below still scopes results to anthropic.com.
+                "Search and name one product Anthropic makes. \
                  Cite the page you used.",
             ))
             .unwrap()

--- a/misanthropic/src/client.rs
+++ b/misanthropic/src/client.rs
@@ -1509,15 +1509,13 @@ mod tests {
         let key = load_api_key().await;
         let client = Client::new(key).unwrap();
 
-        let message = client
-            .message(
-                Prompt::default()
-                    .messages([(
-                        Role::User,
-                        "Emit just the \"🙏\" emoji, please.",
-                    )])
-                    .unwrap(),
-            )
+        let prompt = Prompt::default()
+            .messages([(Role::User, "Emit just the \"🙏\" emoji, please.")])
+            .unwrap();
+        let message =
+            crate::utils::retry_transient("test_client_message", || {
+                client.message(&prompt)
+            })
             .await
             .unwrap();
 
@@ -1711,7 +1709,10 @@ mod tests {
                 ..Default::default()
             };
 
-            let outcome = client.count_tokens(&prompt).await;
+            let outcome = crate::utils::retry_transient(case, || {
+                client.count_tokens(&prompt)
+            })
+            .await;
             match expect {
                 None => {
                     assert!(outcome.is_ok(), "{case}: {outcome:?}");
@@ -1789,7 +1790,12 @@ mod tests {
         let mut urls: Vec<String> = Vec::new();
         let mut pauses = 0u32;
         loop {
-            let response = client.message(&prompt).await.unwrap();
+            let response = crate::utils::retry_transient(
+                "test_web_search_server_tool",
+                || client.message(&prompt),
+            )
+            .await
+            .unwrap();
             if let Some(usage) = response.usage.server_tool_use {
                 total_searches += usage.web_search_requests;
             }
@@ -1882,7 +1888,12 @@ mod tests {
         let mut calls_made = 0u32;
         let mut pauses = 0u32;
         let answer = loop {
-            let response = client.message(&prompt).await.unwrap();
+            let response = crate::utils::retry_transient(
+                "test_programmatic_tool_calling",
+                || client.message(&prompt),
+            )
+            .await
+            .unwrap();
 
             if let Some(container) = &response.container {
                 prompt.container = Some(container.id.clone());
@@ -2013,7 +2024,12 @@ mod tests {
         let mut urls: Vec<String> = Vec::new();
         let mut pauses = 0u32;
         loop {
-            let response = client.message(&prompt).await.unwrap();
+            let response = crate::utils::retry_transient(
+                "test_web_fetch_server_tool",
+                || client.message(&prompt),
+            )
+            .await
+            .unwrap();
             if let Some(usage) = response.usage.server_tool_use {
                 total_fetches += usage.web_fetch_requests;
             }
@@ -2079,7 +2095,12 @@ mod tests {
         let mut saw_bash = false;
         let mut pauses = 0u32;
         loop {
-            let response = client.message(&prompt).await.unwrap();
+            let response = crate::utils::retry_transient(
+                "test_code_execution_server_tool",
+                || client.message(&prompt),
+            )
+            .await
+            .unwrap();
 
             for block in response.inner.content.iter() {
                 match block {
@@ -2150,15 +2171,13 @@ mod tests {
         let key = load_api_key().await;
         let client = Client::new(key).unwrap();
 
-        let stream = client
-            .stream(
-                Prompt::default()
-                    .messages([(
-                        Role::User,
-                        "Emit just the \"🙏\" emoji, please.",
-                    )])
-                    .unwrap(),
-            )
+        let prompt = Prompt::default()
+            .messages([(Role::User, "Emit just the \"🙏\" emoji, please.")])
+            .unwrap();
+        let stream =
+            crate::utils::retry_transient("test_client_stream", || {
+                client.stream(&prompt)
+            })
             .await
             .unwrap();
 
@@ -2177,12 +2196,13 @@ mod tests {
         let key = load_api_key().await;
         let client = Client::new(key).unwrap();
 
-        let count = client
-            .count_tokens(
-                Prompt::default()
-                    .messages([(Role::User, "Hello, world!")])
-                    .unwrap(),
-            )
+        let prompt = Prompt::default()
+            .messages([(Role::User, "Hello, world!")])
+            .unwrap();
+        let count =
+            crate::utils::retry_transient("test_client_count_tokens", || {
+                client.count_tokens(&prompt)
+            })
             .await
             .unwrap();
 
@@ -2199,7 +2219,12 @@ mod tests {
         let key = load_api_key().await;
         let client = Client::new(key).unwrap();
 
-        let models = client.models().await.unwrap();
+        let models =
+            crate::utils::retry_transient("test_client_models", || {
+                client.models()
+            })
+            .await
+            .unwrap();
         assert!(!models.is_empty());
         for model in models.iter() {
             dbg!(&model);

--- a/misanthropic/src/model.rs
+++ b/misanthropic/src/model.rs
@@ -1002,6 +1002,12 @@ mod tests {
             Id::Haiku35_20241022,
             Id::Opus30,
             Id::Opus30_20240229,
+            // Claude 4.0 dated snapshots retired 2026-06-15 (#118): the id is
+            // still recognized (404 "model: …", not an unknown-model error) but
+            // no longer served. The undated `-4-0` aliases resolve server-side
+            // and stay live.
+            Id::Opus40_20250514,
+            Id::Sonnet40_20250514,
             Id::Sonnet35,
             Id::Sonnet35_20240620,
             Id::Sonnet35_20241022,

--- a/misanthropic/src/model.rs
+++ b/misanthropic/src/model.rs
@@ -1036,30 +1036,15 @@ mod tests {
             //
             // 15 sequential live calls — concurrently with the rest of the
             // `--ignored` suite — *will* see transient 429/529s, so retry
-            // those rather than flake. `retry_after()` is the designed
-            // discriminator (`Some` only for RateLimit/Overloaded), though
-            // a 529 can arrive without the header — seen live 2026-06-11 —
-            // so header-less Overloaded gets a small backoff instead.
-            let mut attempts = 0;
-            let response = loop {
-                use crate::client::{AnthropicError, Error};
-                match client.message(&prompt).await {
-                    Ok(response) => break response,
-                    Err(Error::Anthropic(e)) if attempts < 5 => {
-                        attempts += 1;
-                        let wait = match (e.retry_after(), &e) {
-                            (Some(hint), _) => hint,
-                            (None, AnthropicError::Overloaded { .. }) => {
-                                std::time::Duration::from_secs(2 * attempts)
-                            }
-                            _ => panic!("{model:?}: {e}"),
-                        };
-                        eprintln!("{model:?}: {e}; retry {attempts}/5");
-                        tokio::time::sleep(wait).await;
-                    }
-                    Err(e) => panic!("{model:?}: {e}"),
-                }
-            };
+            // those rather than flake, backing off on `retry_after()` (see
+            // `crate::utils::retry_transient`). A non-retryable error (e.g. a
+            // genuine 404 for a typo'd/retired id) still surfaces here.
+            let response =
+                crate::utils::retry_transient(&format!("{model:?}"), || {
+                    client.message(&prompt)
+                })
+                .await
+                .unwrap_or_else(|e| panic!("{model:?}: {e}"));
 
             // Only date-pinned ids echo back verbatim; aliases (3.x
             // `-latest`, 4.x+ undated like `claude-opus-4-0`) resolve

--- a/misanthropic/src/model.rs
+++ b/misanthropic/src/model.rs
@@ -7,12 +7,70 @@ use serde::{Deserialize, Serialize};
 
 use crate::prompt::Effort;
 
-/// All available models.
-#[derive(Debug, Serialize, Deserialize, derive_more::Deref)]
+/// All available models, as returned by
+/// [`Client::models`](crate::Client::models) — a thin wrapper over a `Vec` of
+/// [`ModelInfo`] that [`Deref`](std::ops::Deref)s (and
+/// [`DerefMut`](std::ops::DerefMut)s) to it.
+///
+/// The wire response nests the list under a `data` key, so this is a struct
+/// rather than a bare `Vec`. [`data`](Self::data) is public and the type is
+/// [`FromIterator`] / [`From<Vec>`](From) so tests can mock a model list
+/// without round-tripping through JSON — e.g.
+/// `[info(Id::Opus48, …)].into_iter().collect::<Models>()`.
+#[derive(
+    Debug,
+    Clone,
+    Default,
+    Serialize,
+    Deserialize,
+    derive_more::Deref,
+    derive_more::DerefMut,
+)]
 #[serde(rename_all = "snake_case")]
 pub struct Models {
     /// List of available models.
-    data: Vec<ModelInfo>,
+    pub data: Vec<ModelInfo>,
+}
+
+impl FromIterator<ModelInfo> for Models {
+    fn from_iter<I: IntoIterator<Item = ModelInfo>>(iter: I) -> Self {
+        Self {
+            data: iter.into_iter().collect(),
+        }
+    }
+}
+
+impl From<Vec<ModelInfo>> for Models {
+    fn from(data: Vec<ModelInfo>) -> Self {
+        Self { data }
+    }
+}
+
+impl IntoIterator for Models {
+    type Item = ModelInfo;
+    type IntoIter = std::vec::IntoIter<ModelInfo>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.data.into_iter()
+    }
+}
+
+impl<'a> IntoIterator for &'a Models {
+    type Item = &'a ModelInfo;
+    type IntoIter = std::slice::Iter<'a, ModelInfo>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.data.iter()
+    }
+}
+
+impl<'a> IntoIterator for &'a mut Models {
+    type Item = &'a mut ModelInfo;
+    type IntoIter = std::slice::IterMut<'a, ModelInfo>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.data.iter_mut()
+    }
 }
 
 /// Model information, as returned by [`Client::models`](crate::Client::models).
@@ -582,6 +640,39 @@ mod tests {
         const JSON:&[u8] = b"{\"data\":[{\"type\":\"model\",\"id\":\"claude-3-5-sonnet-20241022\",\"display_name\":\"Claude 3.5 Sonnet (New)\",\"created_at\":\"2024-10-22T00:00:00Z\"},{\"type\":\"model\",\"id\":\"claude-3-5-haiku-20241022\",\"display_name\":\"Claude 3.5 Haiku\",\"created_at\":\"2024-10-22T00:00:00Z\"},{\"type\":\"model\",\"id\":\"claude-3-5-sonnet-20240620\",\"display_name\":\"Claude 3.5 Sonnet (Old)\",\"created_at\":\"2024-06-20T00:00:00Z\"},{\"type\":\"model\",\"id\":\"claude-3-haiku-20240307\",\"display_name\":\"Claude 3 Haiku\",\"created_at\":\"2024-03-07T00:00:00Z\"},{\"type\":\"model\",\"id\":\"claude-3-opus-20240229\",\"display_name\":\"Claude 3 Opus\",\"created_at\":\"2024-02-29T00:00:00Z\"},{\"type\":\"model\",\"id\":\"claude-3-sonnet-20240229\",\"display_name\":\"Claude 3 Sonnet\",\"created_at\":\"2024-02-29T00:00:00Z\"},{\"type\":\"model\",\"id\":\"claude-2.1\",\"display_name\":\"Claude 2.1\",\"created_at\":\"2023-11-21T00:00:00Z\"},{\"type\":\"model\",\"id\":\"claude-2.0\",\"display_name\":\"Claude 2.0\",\"created_at\":\"2023-07-11T00:00:00Z\"}],\"has_more\":false,\"first_id\":\"claude-3-5-sonnet-20241022\",\"last_id\":\"claude-2.0\"}";
         let models = serde_json::from_slice::<Models>(JSON).unwrap();
         assert_eq!(models.len(), 8);
+    }
+
+    /// #119: a `Models` can be built without deserializing — from an iterator,
+    /// from a `Vec`, or mutated in place through `DerefMut` — so tests can mock
+    /// the model list. `data` is public too.
+    #[test]
+    fn test_models_construct_for_mocking() {
+        let offered = [
+            info(Id::Opus48, 200_000, 64_000),
+            info(Id::Haiku45, 200_000, 64_000),
+        ];
+
+        // FromIterator / .collect()
+        let mut models: Models = offered.iter().cloned().collect();
+        assert_eq!(models.len(), 2); // via Deref<Target = Vec<_>>
+        assert_eq!(models[0].id, Id::Opus48);
+
+        // DerefMut lets it be mutated in place.
+        models.push(info(Id::Sonnet45, 200_000, 64_000));
+        assert_eq!(models.len(), 3);
+        models.pop();
+
+        // From<Vec> and the public `data` field.
+        let from_vec = Models::from(offered.to_vec());
+        assert_eq!(from_vec.data.len(), 2);
+
+        // IntoIterator by value.
+        let ids: Vec<Model> = from_vec.into_iter().map(|m| m.id).collect();
+        assert_eq!(ids, [Id::Opus48, Id::Haiku45]); // Model: PartialEq<Id>
+
+        // Round-trips through the wire shape it deserializes from.
+        let json = serde_json::to_string(&models).unwrap();
+        assert_eq!(serde_json::from_str::<Models>(&json).unwrap().len(), 2);
     }
 
     #[test]

--- a/misanthropic/src/prompt/citation.rs
+++ b/misanthropic/src/prompt/citation.rs
@@ -258,7 +258,12 @@ mod tests {
             ))
             .unwrap();
 
-        let message = client.message(prompt).await.unwrap();
+        let message = crate::utils::retry_transient(
+            "live_text_document_returns_citation",
+            || client.message(&prompt),
+        )
+        .await
+        .unwrap();
 
         // The answer must be grounded in the document, not world knowledge.
         assert!(
@@ -323,7 +328,12 @@ mod tests {
             ))
             .unwrap();
 
-        let message = client.message(prompt).await.unwrap();
+        let message = crate::utils::retry_transient(
+            "live_pdf_document_returns_page_citation",
+            || client.message(&prompt),
+        )
+        .await
+        .unwrap();
 
         // Grounded in the PDF, not world knowledge.
         let answer = message.to_string().to_lowercase();
@@ -385,7 +395,12 @@ mod tests {
         // First turn: the model cites the PDF. Our fixture has no title, so
         // the returned citation's `document_title` is `None` — the exact shape
         // that broke the round-trip.
-        let first = client.message(&prompt).await.unwrap();
+        let first = crate::utils::retry_transient(
+            "live_multi_turn_echoes_untitled_citation:first",
+            || client.message(&prompt),
+        )
+        .await
+        .unwrap();
         let assistant: Message = Message::from(first);
 
         // Second turn: echo the cited assistant turn back, then follow up.
@@ -395,7 +410,12 @@ mod tests {
             .add_message((Role::User, "And what are its two moons named?"))
             .unwrap();
 
-        let second = client.message(&prompt).await.unwrap();
+        let second = crate::utils::retry_transient(
+            "live_multi_turn_echoes_untitled_citation:second",
+            || client.message(&prompt),
+        )
+        .await
+        .unwrap();
         let answer = second.to_string().to_lowercase();
         assert!(
             answer.contains("pim") && answer.contains("wassel"),

--- a/misanthropic/src/prompt/output.rs
+++ b/misanthropic/src/prompt/output.rs
@@ -590,7 +590,12 @@ mod tests {
             ))
             .unwrap();
 
-        let response = client.message(&prompt).await.expect("API call");
+        let response = crate::utils::retry_transient(
+            "live_structured_output_roundtrip",
+            || client.message(&prompt),
+        )
+        .await
+        .expect("API call");
         let fact: CapitalFact = response
             .json()
             .expect("json() should parse structured output");

--- a/misanthropic/src/tool/memory.rs
+++ b/misanthropic/src/tool/memory.rs
@@ -914,7 +914,12 @@ mod tests {
         // Drive the tool loop exactly as the example does.
         let mut turns = 0;
         loop {
-            let message = client.message(&chat).await.unwrap();
+            let message = crate::utils::retry_transient(
+                "live_memory_tool_writes_to_disk",
+                || client.message(&chat),
+            )
+            .await
+            .unwrap();
             turns += 1;
             assert!(turns <= 12, "runaway memory loop ({turns} turns)");
             let Some(call) = message.tool_use() else {

--- a/misanthropic/src/tool/text_editor.rs
+++ b/misanthropic/src/tool/text_editor.rs
@@ -733,7 +733,12 @@ def get_primes(limit):
         // Drive the tool loop exactly as the example does.
         let mut turns = 0;
         loop {
-            let message = client.message(&chat).await.unwrap();
+            let message = crate::utils::retry_transient(
+                "live_text_editor_fixes_file_on_disk",
+                || client.message(&chat),
+            )
+            .await
+            .unwrap();
             turns += 1;
             assert!(turns <= 12, "runaway editor loop ({turns} turns)");
             let Some(call) = message.tool_use() else {

--- a/misanthropic/src/utils.rs
+++ b/misanthropic/src/utils.rs
@@ -239,3 +239,210 @@ pub(crate) async fn load_api_key() -> String {
         .trim()
         .to_string()
 }
+
+/// Retry a live API call while Anthropic returns a *retryable* error, backing
+/// off on the server's own `retry_after` hint — the only wait we can trust —
+/// then return whatever it finally yields (`Ok`, or a non-retryable `Err` for
+/// the caller to inspect).
+///
+/// Shared by the `#[ignore]`d live tests so the push-to-`main` coverage run
+/// rides out a transient 429/529 instead of reding the CI badge (#116), and
+/// without the harness inventing a delay a conservative rate limiter might
+/// count against us (the argument against a blind `nextest --retries`).
+///
+/// Only `RateLimit` (429) and `Overloaded` (529) are retried, and only for a
+/// wait we can justify: the `retry_after` hint, or — for a header-less 529,
+/// which the API does emit (seen live 2026-06-11) — a small courtesy backoff.
+/// A header-less 429 (which should carry the header) and every other error are
+/// surfaced unchanged. Gives up after `MAX` attempts, returning the last error.
+///
+/// This is the one path outside `model::tests::test_ids_are_valid` that
+/// exercises [`AnthropicError::retry_after`](crate::client::AnthropicError::retry_after).
+#[cfg(all(test, feature = "client"))]
+pub(crate) async fn retry_transient<F, Fut, T>(
+    what: &str,
+    mut op: F,
+) -> crate::client::Result<T>
+where
+    F: FnMut() -> Fut,
+    Fut: std::future::Future<Output = crate::client::Result<T>>,
+{
+    /// Retries before giving up and surfacing the last error.
+    const MAX: u32 = 5;
+
+    let mut attempt = 0;
+    loop {
+        match op().await {
+            Ok(value) => return Ok(value),
+            // `retry_backoff` decides purely from `&err`, so no borrow is held
+            // across the `return Err(err)`.
+            Err(err) => match retry_backoff(&err, attempt + 1) {
+                Some(wait) if attempt < MAX => {
+                    attempt += 1;
+                    eprintln!(
+                        "{what}: retryable {err}; \
+                         attempt {attempt}/{MAX} after {wait:?}"
+                    );
+                    tokio::time::sleep(wait).await;
+                }
+                _ => return Err(err),
+            },
+        }
+    }
+}
+
+/// The backoff policy behind [`retry_transient`]: how long to wait before the
+/// `attempt`-th retry (1-indexed) of `err`, or `None` if `err` is not
+/// retryable. Only `RateLimit` (429) / `Overloaded` (529) are retryable, and
+/// only for a wait we can justify — the `retry_after` hint, or a small courtesy
+/// backoff for a header-less 529 (which the API does emit). Pure, so the policy
+/// is unit-testable without touching the clock or the network.
+#[cfg(all(test, feature = "client"))]
+fn retry_backoff(
+    err: &crate::client::Error,
+    attempt: u32,
+) -> Option<std::time::Duration> {
+    use crate::client::{AnthropicError, Error};
+    use std::time::Duration;
+
+    match err {
+        Error::Anthropic(e) => match (e.retry_after(), e) {
+            (Some(hint), _) => Some(hint),
+            (None, AnthropicError::Overloaded { .. }) => {
+                Some(Duration::from_secs(2 * u64::from(attempt)))
+            }
+            _ => None,
+        },
+        _ => None,
+    }
+}
+
+#[cfg(all(test, feature = "client"))]
+mod retry_tests {
+    use super::retry_transient;
+    use crate::client::{AnthropicError, Error, Result};
+    use std::cell::Cell;
+    use std::time::Duration;
+
+    fn rate_limit(retry_after: Option<u64>) -> Error {
+        Error::Anthropic(AnthropicError::RateLimit {
+            message: "slow down".into(),
+            retry_after,
+        })
+    }
+    fn overloaded(retry_after: Option<u64>) -> Error {
+        Error::Anthropic(AnthropicError::Overloaded {
+            message: "busy".into(),
+            retry_after,
+        })
+    }
+    fn invalid() -> Error {
+        Error::Anthropic(AnthropicError::InvalidRequest {
+            message: "nope".into(),
+        })
+    }
+
+    /// The pure policy: what's retryable, and for how long. Covers the
+    /// header-less-529 courtesy backoff without sleeping.
+    #[test]
+    fn backoff_policy() {
+        use super::retry_backoff;
+
+        // The `retry_after` hint is honored verbatim, on both retryable kinds
+        // and independent of the attempt number.
+        assert_eq!(
+            retry_backoff(&rate_limit(Some(3)), 1),
+            Some(Duration::from_secs(3))
+        );
+        assert_eq!(
+            retry_backoff(&overloaded(Some(1)), 9),
+            Some(Duration::from_secs(1))
+        );
+
+        // Header-less 529: a small backoff that grows with the attempt.
+        assert_eq!(
+            retry_backoff(&overloaded(None), 1),
+            Some(Duration::from_secs(2))
+        );
+        assert_eq!(
+            retry_backoff(&overloaded(None), 3),
+            Some(Duration::from_secs(6))
+        );
+
+        // Not retryable: a header-less 429 (should carry the header), a plain
+        // 4xx, and any non-Anthropic error are all surfaced, never guessed at.
+        assert_eq!(retry_backoff(&rate_limit(None), 1), None);
+        assert_eq!(retry_backoff(&invalid(), 1), None);
+        assert_eq!(
+            retry_backoff(&Error::UnexpectedResponse { message: "x" }, 1),
+            None
+        );
+    }
+
+    /// Succeeds on the first try — no retry, no wait.
+    #[tokio::test]
+    async fn returns_first_ok() {
+        let calls = Cell::new(0u32);
+        let out: Result<u8> = retry_transient("t", || {
+            calls.set(calls.get() + 1);
+            async { Ok(7) }
+        })
+        .await;
+        assert_eq!(out.unwrap(), 7);
+        assert_eq!(calls.get(), 1);
+    }
+
+    /// A retryable error (with a zero-second hint, so the sleep is instant)
+    /// retries, then the next `Ok` is returned.
+    #[tokio::test]
+    async fn retries_then_succeeds() {
+        let calls = Cell::new(0u32);
+        let out: Result<u8> = retry_transient("t", || {
+            let n = calls.get() + 1;
+            calls.set(n);
+            async move {
+                if n >= 3 {
+                    Ok(7)
+                } else {
+                    Err(rate_limit(Some(0)))
+                }
+            }
+        })
+        .await;
+        assert_eq!(out.unwrap(), 7);
+        assert_eq!(calls.get(), 3);
+    }
+
+    /// A persistently retryable error gives up after `MAX` retries (6 total
+    /// calls) and surfaces the last error.
+    #[tokio::test]
+    async fn gives_up_after_max() {
+        let calls = Cell::new(0u32);
+        let out: Result<u8> = retry_transient("t", || {
+            calls.set(calls.get() + 1);
+            async { Err(overloaded(Some(0))) }
+        })
+        .await;
+        assert!(matches!(
+            out,
+            Err(Error::Anthropic(AnthropicError::Overloaded { .. }))
+        ));
+        assert_eq!(calls.get(), 6); // initial + MAX (5) retries
+    }
+
+    /// A non-retryable error is surfaced immediately, without a retry.
+    #[tokio::test]
+    async fn surfaces_non_retryable() {
+        let calls = Cell::new(0u32);
+        let out: Result<u8> = retry_transient("t", || {
+            calls.set(calls.get() + 1);
+            async { Err(invalid()) }
+        })
+        .await;
+        assert!(matches!(
+            out,
+            Err(Error::Anthropic(AnthropicError::InvalidRequest { .. }))
+        ));
+        assert_eq!(calls.get(), 1);
+    }
+}


### PR DESCRIPTION
Closes #119, #118, #117, #116. Bumps the workspace to `1.0.0-alpha.6`.

## #119 — `Models` constructible without deserializing

`Models` wrapped a private `data: Vec<ModelInfo>`, so downstream tests could only build one by round-tripping JSON. Now:

- `data` is `pub`.
- `FromIterator<ModelInfo>` + `From<Vec<ModelInfo>>` → `.collect()` / `.into()`.
- `DerefMut` and by-value / by-ref / by-mut `IntoIterator` for a full `Vec`-like surface (`for m in &models` works).
- derives `Clone` + `Default`, so an empty `Models` you `.push()` to is a valid mock.

```rust
let mocked: Models = [info(Id::Opus48, 200_000, 64_000)].into_iter().collect();
```

Breaking (`feat!`) only in that the field is now `pub` — no existing call site in the workspace touched `data` directly.

## #118 — retire Claude 4.0 dated snapshots from the live probe

`claude-opus-4-20250514` / `claude-sonnet-4-20250514` retired 2026-06-15; the grace period lapsed and they now 404 (`model: …`, i.e. recognized-but-not-served) on `test_ids_are_valid`. Both move into the `RETIRED` list per the "when a model retires, move it here — consciously" discipline. The variants and their undated `-4-0` aliases stay.

## #117 — de-flake `test_web_search_server_tool`

`allowed_domains` is a server-side result filter the model never sees, so "Search anthropic.com …" asked Haiku to honor a restriction it couldn't express, and it declined. The prompt now just says "Search …"; the `allowed_domains` filter still scopes results to anthropic.com server-side.

## #116 — live CI resilient to 429/529, via `retry_after`

The push-to-`main` coverage run is the only CI job that hits the live API, so a transient `429`/`529` there reds the badge. Rather than a blind `nextest --retries` (which retries *immediately* — Anthropic is conservative about rate limits, and an un-delayed retry can make it worse), the live tests now back off on the one signal we can trust: the server's `retry_after` hint.

- New `utils::retry_transient` test helper (per #104 the retry stays out of `Client`): retries `RateLimit`/`Overloaded` on the `retry_after` hint, with a small courtesy backoff for a header-less `529` (which the API does send), and surfaces everything else unchanged.
- Every `#[ignore]`d live test routes its API calls through it; `test_ids_are_valid`'s hand-rolled retry loop collapses into it. This is now the main path exercising the `retry_after()` accessor the crate ships.

## Not included: #115

The cache-coverage-on-PR / reuse-on-release idea is a follow-up — it's a cross-run cache rewrite on the release-critical path that's better proven on its own PR. Plan captured on #115.

## Testing

Offline gate green: `fmt --check`, `clippy --all-features --all-targets`, `RUSTDOCFLAGS=-D warnings` doc, and `cargo test` on both `--all-features` and `--no-default-features` (plus a `--features client`-only compile of the live tests). The touched `#[ignore]`d live tests compile; their behavior needs an `api.key` run (the push coverage job) to confirm end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)