### PR TITLE
feat(tool): `#[tool(flat)]` + `ToolBox::flat()` for bare wire method names

### DIFF
--- a/.claude/skills/misan-messages-api/SKILL.md
+++ b/.claude/skills/misan-messages-api/SKILL.md
@@ -330,7 +330,13 @@ Notes on the macro:
 
 - Each `#[method]` becomes a real inherent method you can still call directly.
 - One `#[tool]` block can hold several `#[method]`s; each is namespaced
-  `TypeName__method_name`.
+  `TypeName__method_name` (and a `ToolBox` adds its own segment:
+  `toolbox__TypeName__method_name`).
+- `#[tool(flat)]` puts method names on the wire **bare** — no `TypeName__`
+  segment. Pair with `ToolBox::flat()` (no `toolbox__` segment either) for
+  fully bare names, e.g. matching an MCP server's `create_post`. Collisions
+  between two tools' bare names are debug-asserted at add time; note that
+  un-flattening later renames the methods (prompt-cache / transcript churn).
 - `#[method(defer_loading)]` marks a method's schema as deferrable for use
   with the tool-search server tool (large tool sets).
 - The `Tool` trait also has `definitions()`, `call()`, plus optional

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -519,7 +519,7 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bashd"
-version = "1.0.0-alpha.6"
+version = "1.0.0-alpha.7"
 dependencies = [
  "async-stream",
  "axum 0.8.9",
@@ -3278,7 +3278,7 @@ dependencies = [
 
 [[package]]
 name = "misanthropic"
-version = "1.0.0-alpha.6"
+version = "1.0.0-alpha.7"
 dependencies = [
  "arboard",
  "async-stream",
@@ -3324,7 +3324,7 @@ dependencies = [
 
 [[package]]
 name = "misanthropic-derive"
-version = "1.0.0-alpha.6"
+version = "1.0.0-alpha.7"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 # Shared package metadata. Members opt in per-field with `version.workspace =
 # true` etc., so the version lives in exactly one place.
 [workspace.package]
-version = "1.0.0-alpha.6"
+version = "1.0.0-alpha.7"
 edition = "2024"
 authors = ["Michael de Gans <michael.john.degans@gmail.com>"]
 homepage = "https://github.com/mdegans/misanthropic"
@@ -26,7 +26,7 @@ rust.missing_docs = "deny"
 # Shared dependency declarations. The inter-crate version/path is defined once
 # here; members use `misanthropic-derive = { workspace = true }`.
 [workspace.dependencies]
-misanthropic-derive = { version = "1.0.0-alpha.6", path = "misanthropic-derive" }
+misanthropic-derive = { version = "1.0.0-alpha.7", path = "misanthropic-derive" }
 
 [profile.release]
 lto = true

--- a/misanthropic-derive/src/lib.rs
+++ b/misanthropic-derive/src/lib.rs
@@ -50,7 +50,9 @@ pub fn derive_tool_args(input: TokenStream) -> TokenStream {
 /// `Result<Content<'static>, Content<'static>>`. The macro keeps your fns as
 /// real inherent methods and generates a thin `Method` per fn that delegates
 /// to them, plus the `Methods` impl. The tool `NAME` defaults to the self
-/// type's ident; override with `#[tool(name = "…")]`.
+/// type's ident; override with `#[tool(name = "…")]`. Add `flat` to put
+/// method names on the wire bare — no `tool__` segment (sets
+/// `Methods::FLAT`; pair with a flat `ToolBox` to drop its segment too).
 ///
 /// ```ignore
 /// #[tool(name = "Notepad")]

--- a/misanthropic-derive/src/tool.rs
+++ b/misanthropic-derive/src/tool.rs
@@ -65,7 +65,10 @@ pub fn expand(attr: TokenStream, item: TokenStream) -> TokenStream {
 fn build(item_impl: &ItemImpl, attr: TokenStream) -> syn::Result<TokenStream> {
     let self_ty = (*item_impl.self_ty).clone();
     let self_ident = self_ty_ident(&self_ty)?;
-    let tool_name = parse_name(attr)?.unwrap_or_else(|| self_ident.to_string());
+    let ToolAttr { name, flat } = parse_tool_attr(attr)?;
+    let tool_name = name.unwrap_or_else(|| self_ident.to_string());
+    // Only emit the const when set, so the trait default (`false`) stands.
+    let flat = flat.then(|| quote! { const FLAT: bool = true; });
 
     // Scan items for `#[method]`s and lifecycle markers (a fn may carry more
     // than one, e.g. `#[on_init] #[on_turn]`).
@@ -167,6 +170,7 @@ fn build(item_impl: &ItemImpl, attr: TokenStream) -> syn::Result<TokenStream> {
         #methods_async
         impl #ig ::misanthropic::tool::Methods for #self_ty #wc {
             const NAME: &'static str = #tool_name;
+            #flat
 
             fn methods(
                 &self,
@@ -488,22 +492,32 @@ fn strip_markers(item_impl: &mut ItemImpl) {
     }
 }
 
-/// Parse the optional `name = "…"` from the `#[tool(…)]` attribute tokens.
-fn parse_name(attr: TokenStream) -> syn::Result<Option<String>> {
+/// The parsed `#[tool(…)]` keys: an optional `name = "…"` and a bare `flat`.
+#[derive(Default)]
+struct ToolAttr {
+    name: Option<String>,
+    flat: bool,
+}
+
+/// Parse the `#[tool(…)]` attribute tokens. See [`ToolAttr`].
+fn parse_tool_attr(attr: TokenStream) -> syn::Result<ToolAttr> {
+    let mut parsed = ToolAttr::default();
     if attr.is_empty() {
-        return Ok(None);
+        return Ok(parsed);
     }
-    let mut name = None;
     let parser = syn::meta::parser(|meta| {
         if meta.path.is_ident("name") {
-            name = Some(meta.value()?.parse::<LitStr>()?.value());
+            parsed.name = Some(meta.value()?.parse::<LitStr>()?.value());
+            Ok(())
+        } else if meta.path.is_ident("flat") {
+            parsed.flat = true;
             Ok(())
         } else {
-            Err(meta.error("unknown `tool` key; expected `name`"))
+            Err(meta.error("unknown `tool` key; expected `name` or `flat`"))
         }
     });
     parser.parse2(attr)?;
-    Ok(name)
+    Ok(parsed)
 }
 
 /// The last path segment ident of the impl's self type, used to mangle wrapper

--- a/misanthropic/src/tool/toolbox.rs
+++ b/misanthropic/src/tool/toolbox.rs
@@ -36,6 +36,9 @@ pub struct ToolBox {
     /// source is the bare tool name); `Some("root/child")` once nested, so
     /// sources compose `parent/child/leaf`.
     source_prefix: Option<String>,
+    /// When `true`, this box adds no `box__` segment to wire names or routes.
+    /// See [`flat`](Self::flat).
+    flat: bool,
 }
 
 impl Default for ToolBox {
@@ -46,6 +49,7 @@ impl Default for ToolBox {
             tool_name_to_tool: HashMap::new(),
             mailbox: Some(Mailbox::new("toolbox")),
             source_prefix: None,
+            flat: false,
         }
     }
 }
@@ -84,6 +88,20 @@ impl ToolBox {
             name,
             ..Self::default()
         })
+    }
+
+    /// Create a `ToolBox` that adds **no** `box__` segment to wire names or
+    /// routes: a [`FLAT`](Methods::FLAT) tool's methods reach the wire
+    /// completely bare (`create_post`), a namespaced tool's as `tool__method`.
+    /// The box still has a [`name`](Tool::name) (state key, mailbox source) —
+    /// flatness only affects method naming. Bare names forfeit the collision
+    /// protection namespacing exists for; [`push_boxed`](Self::push_boxed)
+    /// debug-asserts that no route is claimed by two different tools.
+    pub fn flat() -> Self {
+        Self {
+            flat: true,
+            ..Self::default()
+        }
     }
 
     /// Add a [`Tool`] to the [`ToolBox`].
@@ -138,15 +156,25 @@ impl ToolBox {
         // model emits exactly that, so prefixing it would break routing. A bare
         // name has no `box__` prefix to strip on descent, so it passes through
         // nested boxes untouched, which is what makes it reachable from the
-        // root.
+        // root. A [`flat`](Self::flat) box adds no segment of its own.
         for def in tool.definitions() {
-            let route = if def.is_server() {
+            let route = if def.is_server() || self.flat {
                 def.name().to_string()
             } else {
                 format!("{}{}{}", self.name, Self::SEP, def.name())
             };
-            self.method_to_tool_name
-                .insert(route.into(), tool.name().to_string());
+            let claimed = self
+                .method_to_tool_name
+                .insert(route.clone().into(), tool.name().to_string());
+            // Two *different* tools claiming one route is unreachable code
+            // waiting to run — the risk `flat` naming reintroduces. Replacing
+            // a same-named tool stays a documented overwrite.
+            debug_assert!(
+                claimed.as_deref().is_none_or(|t| t == tool.name()),
+                "method route `{route}` already claimed by tool \
+                 `{}`; renaming or un-flattening one of the tools is required",
+                claimed.as_deref().unwrap_or_default(),
+            );
         }
 
         // Hand the tool a send-only handle on this box's channel, stamped with
@@ -332,8 +360,11 @@ impl Tool for ToolBox {
                     // Prefix custom method names with this box's segment
                     // (they already carry `tool__method`); leave server defs
                     // bare so their fixed wire name survives every nesting
-                    // level. See [`push_boxed`](Self::push_boxed).
-                    if let Some(method) = def.as_method_mut() {
+                    // level, and add nothing when the box is
+                    // [`flat`](Self::flat). See [`push_boxed`](Self::push_boxed).
+                    if !self.flat
+                        && let Some(method) = def.as_method_mut()
+                    {
                         method.name = Cow::Owned(format!(
                             "{}{}{}",
                             self.name(),
@@ -388,11 +419,15 @@ impl Tool for ToolBox {
             // keys its routes by its *own* name only (`tool__method`), so it
             // would not recognize the outer-qualified `box__tool__method` we
             // looked up here. Leaf tools rsplit on [`Self::SEP`] and read only
-            // the final segment, so this is a no-op for them.
+            // the final segment, so this is a no-op for them. A
+            // [`flat`](Self::flat) box added no segment, so none is stripped —
+            // guarded rather than assumed, against a method name that happens
+            // to start with `{box}__`.
             let mut call = call;
             let prefix = format!("{}{}", self.name, Self::SEP);
-            if let Some(rest) =
-                call.name.strip_prefix(prefix.as_str()).map(str::to_owned)
+            if !self.flat
+                && let Some(rest) =
+                    call.name.strip_prefix(prefix.as_str()).map(str::to_owned)
             {
                 call.name = Cow::Owned(rest);
             }

--- a/misanthropic/src/tool/typed.rs
+++ b/misanthropic/src/tool/typed.rs
@@ -165,6 +165,13 @@ pub trait Methods: Send + Sized {
     /// Tool name.
     const NAME: &'static str;
 
+    /// When `true`, method names go on the wire **bare** — no `tool__` segment
+    /// (see [`methods_definitions`]). [`NAME`](Self::NAME) still names the tool
+    /// itself (registry key, mailbox source). Set with `#[tool(flat)]`. Pair
+    /// with [`ToolBox::flat`](super::ToolBox::flat) to drop the box segment
+    /// too. Suffix routing makes dispatch indifferent to the choice.
+    const FLAT: bool = false;
+
     /// The methods this tool provides, erased so heterogeneous `Args` coexist.
     fn methods(&self) -> Vec<Box<dyn ErasedMethod<Self>>>;
 
@@ -205,16 +212,18 @@ pub trait Methods: Send + Sized {
 /// Namespace each of `tool`'s methods as `tool__method` for the wire, so
 /// distinct tools sharing a bare method name (e.g. two `push`es) don't collide
 /// in a [`ToolBox`](super::ToolBox), which further prefixes its own name
-/// (`box__tool__method`). Shared by [`Typed`] and the `#[tool]`-generated
-/// `impl Tool`.
+/// (`box__tool__method`). A [`FLAT`](Methods::FLAT) tool skips its segment.
+/// Shared by [`Typed`] and the `#[tool]`-generated `impl Tool`.
 #[doc(hidden)]
 pub fn methods_definitions<M: Methods>(tool: &M) -> Vec<tool::MethodDef> {
     tool.methods()
         .iter()
         .map(|m| {
             let mut def = m.definition();
-            def.name =
-                format!("{}{}{}", M::NAME, ToolBox::SEP, def.name).into();
+            if !M::FLAT {
+                def.name =
+                    format!("{}{}{}", M::NAME, ToolBox::SEP, def.name).into();
+            }
             tool::MethodDef::Custom(def)
         })
         .collect()
@@ -443,5 +452,51 @@ mod tests {
             .collect();
         assert!(names.contains(&"notes__push".to_string()));
         assert!(names.contains(&"notes__clear".to_string()));
+    }
+
+    // A hand-written `Methods` with `FLAT = true` — the non-macro flat path.
+    #[derive(Default)]
+    struct BareNotes {
+        notes: Vec<String>,
+    }
+
+    struct BarePush;
+    #[async_trait::async_trait]
+    impl Method<BareNotes> for BarePush {
+        type Args = Push;
+        async fn run(
+            &self,
+            state: &mut BareNotes,
+            args: Push,
+        ) -> std::result::Result<Content, Content> {
+            state.notes.push(args.note);
+            Ok("noted".into())
+        }
+    }
+
+    impl Methods for BareNotes {
+        const NAME: &'static str = "bare_notes";
+        const FLAT: bool = true;
+        fn methods(&self) -> Vec<Box<dyn ErasedMethod<Self>>> {
+            vec![Box::new(BarePush) as Box<dyn ErasedMethod<Self>>]
+        }
+    }
+
+    #[tokio::test]
+    async fn flat_definitions_skip_the_tool_segment() {
+        let mut tool = Typed(BareNotes::default());
+        let names: Vec<_> = tool
+            .definitions()
+            .into_iter()
+            .map(|d| d.name().to_string())
+            .collect();
+        assert_eq!(names, vec!["push".to_string()]);
+
+        // Bare-name dispatch (suffix routing degenerates to the whole name).
+        let r = tool
+            .call(call_with("push", serde_json::json!({"note": "hi"})))
+            .await;
+        assert!(!r.is_error, "{}", r.content);
+        assert_eq!(tool.0.notes, vec!["hi".to_string()]);
     }
 }

--- a/misanthropic/tests/tool_attr.rs
+++ b/misanthropic/tests/tool_attr.rs
@@ -243,6 +243,114 @@ async fn generic_tool_defaults_name_to_ident() {
     assert_eq!(holder.0.items.len(), 1);
 }
 
+// A `#[tool(flat)]` tool: method names reach the wire bare.
+#[derive(Deserialize, JsonSchema)]
+struct Ping {}
+
+#[derive(Default)]
+struct Sonar {
+    pings: usize,
+}
+
+#[tool(flat, name = "sonar")]
+impl Sonar {
+    /// Ping.
+    #[method]
+    async fn ping(&mut self, _args: Ping) -> Result<Content, Content> {
+        self.pings += 1;
+        Ok("pong".into())
+    }
+}
+
+// A second flat tool sharing `Sonar`'s method *name*, to prove the route
+// collision assert. Its own `Args` type: the macro impls `ToolArgs` on the
+// args struct, so one struct can't serve methods of two tools.
+#[derive(Deserialize, JsonSchema)]
+struct PingB {}
+
+#[derive(Default)]
+struct SonarB;
+
+#[tool(flat, name = "sonar_b")]
+impl SonarB {
+    /// Ping.
+    #[method]
+    async fn ping(&mut self, _args: PingB) -> Result<Content, Content> {
+        Ok("pong".into())
+    }
+}
+
+#[test]
+// Pins a compile-time associated const, like `DEFER_LOADING` above.
+#[allow(clippy::assertions_on_constants)]
+fn flat_definitions_are_bare() {
+    assert!(<Sonar as Methods>::FLAT);
+    assert!(!<Calc as Methods>::FLAT);
+    let names: Vec<_> = Typed(Sonar::default())
+        .definitions()
+        .into_iter()
+        .map(|d| d.name().to_string())
+        .collect();
+    assert_eq!(names, vec!["ping".to_string()]);
+}
+
+#[tokio::test]
+async fn flat_tool_in_flat_toolbox_is_bare_end_to_end() {
+    use misanthropic::tool::ToolBox;
+
+    let mut tools = ToolBox::flat().add(Sonar::default());
+    let mut prompt = Prompt::default();
+    tools.prepare(&mut prompt).await.unwrap();
+
+    let names: Vec<_> = prompt
+        .tools
+        .as_ref()
+        .unwrap()
+        .iter()
+        .map(|d| d.name().to_string())
+        .collect();
+    assert_eq!(names, vec!["ping".to_string()]);
+
+    // The model emits exactly the installed name; it must route.
+    let r = tools.call(use_call("ping", serde_json::json!({}))).await;
+    assert!(!r.is_error, "{}", r.content);
+    assert_eq!(r.content.to_string(), "pong");
+}
+
+#[tokio::test]
+async fn flat_tool_in_default_toolbox_keeps_the_box_segment() {
+    use misanthropic::tool::ToolBox;
+
+    // Only the tool is flat: the (non-flat) box still adds its segment.
+    let mut tools = ToolBox::new().add(Sonar::default());
+    let mut prompt = Prompt::default();
+    tools.prepare(&mut prompt).await.unwrap();
+
+    let names: Vec<_> = prompt
+        .tools
+        .as_ref()
+        .unwrap()
+        .iter()
+        .map(|d| d.name().to_string())
+        .collect();
+    assert_eq!(names, vec!["toolbox__ping".to_string()]);
+
+    let r = tools
+        .call(use_call("toolbox__ping", serde_json::json!({})))
+        .await;
+    assert!(!r.is_error, "{}", r.content);
+}
+
+#[test]
+#[cfg(debug_assertions)]
+#[should_panic(expected = "already claimed")]
+fn flat_route_collision_asserts_in_debug() {
+    use misanthropic::tool::ToolBox;
+
+    // Two different flat tools exposing the same bare method name.
+    let _ = ToolBox::flat().add(Sonar::default()).add(SonarB);
+}
+
 #[tokio::test]
 async fn save_and_load_round_trip() {
     let mut calc = Calc {


### PR DESCRIPTION
Closes #122.

Today every wire method name carries two segments: the macro adds `TypeName__method` and the `ToolBox` adds `toolbox__` on top. For a box holding a single tool, both segments cost tokens without disambiguating anything, and they diverge from bare names used elsewhere for the same actions (e.g. an MCP server exposing `create_post` while the boxed tool says `toolbox__agora__create_post`).

## Changes

- **`Methods::FLAT`** (default `false`): when `true`, `methods_definitions` skips the `TypeName__` segment. Set via **`#[tool(flat)]`** (composes with `name = "…"`, which still names the tool itself — registry key, mailbox source).
- **`ToolBox::flat()`**: a box that adds no `toolbox__` segment to wire names or routes. Flat tool + flat box = fully bare names.
- **Add-time collision check**: `push_boxed` now `debug_assert`s that no route is claimed by two *different* tools — the risk bare names reintroduce. Replacing a same-named tool stays a documented overwrite.
- Dispatch is untouched: suffix routing already degenerates to the whole name when there is no prefix, and nested boxes compose (the strip on descent is guarded by `flat`).
- Skill docs (`misan-messages-api`) updated under the macro notes.
- Workspace bumped to **1.0.0-alpha.7** for the release pipeline.

Per the issue discussion: auto-skipping when a box happens to hold one tool was rejected — adding a second tool later would silently rename the first tool's methods (prompt-cache and transcript churn). `flat` is explicit opt-in instead.

First consumer: `agora-agentkit`'s `SeedAgent` Agora tool, whose method names must match the live agents' bare `create_post`/`cast_vote`/… vocabulary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)